### PR TITLE
fix(ci): remove nonexistent Python/uv infrastructure from docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,18 +24,11 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up Python
-        uses: wphillipmoore/standard-actions/actions/python/setup@develop
-        with:
-          python-version: "3.14"
-          cache-prefix: "uv-docs"
-
-      - name: Install dependencies
-        run: uv sync --frozen --group docs
-
       - name: Deploy docs
         uses: wphillipmoore/standard-actions/actions/docs-deploy@develop
         with:
-          version-command: ruby -e "require_relative 'lib/mq/rest/admin/version'; v = MQ::REST::Admin::VERSION; puts v.split('.')[0..1].join('.')"
-          mike-command: uv run mike
+          version-command: >-
+            ruby -e "require_relative 'lib/mq/rest/admin/version';
+            v = MQ::REST::Admin::VERSION;
+            puts v.split('.')[0..1].join('.')"
           checkout-common: "true"


### PR DESCRIPTION
# Pull Request

## Summary

- Remove nonexistent Python/uv infrastructure from docs workflow, matching the Go port pattern where docs-deploy handles its own MkDocs setup

## Issue Linkage

- Fixes #6

## Testing

- markdownlint
- `bundle exec rake`

## Notes

- -