### PR TITLE
feat(ci): run integration tests with same Ruby version matrix as unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,6 +185,10 @@ jobs:
     name: "test: integration"
     runs-on: ubuntu-latest
     needs: docs-only
+    strategy:
+      matrix:
+        ruby-version: ["3.2", "3.3", "3.4"]
+
     steps:
       - name: Docs-only short-circuit
         if: needs.docs-only.outputs.docs-only == 'true'
@@ -198,7 +202,7 @@ jobs:
         if: needs.docs-only.outputs.docs-only != 'true'
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.4"
+          ruby-version: ${{ matrix.ruby-version }}
           bundler-cache: true
 
       - name: Setup MQ environment


### PR DESCRIPTION
# Pull Request

## Summary

- Run integration tests with the same Ruby version matrix (3.2, 3.3, 3.4) as unit tests for consistent coverage

## Issue Linkage

- Ref #85

## Testing

- markdownlint
- `bundle exec rake`

## Notes

- -