### PR TITLE
ci: assign unique REST API ports per integration test matrix entry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,7 +182,7 @@ jobs:
           language: ruby
 
   integration-tests:
-    name: "test: integration"
+    name: "test: integration (${{ matrix.ruby-version }})"
     runs-on: ubuntu-latest
     needs: docs-only
     strategy:


### PR DESCRIPTION
# Pull Request

## Summary

- Assign unique QM1/QM2 REST API ports (9459-9464) per Ruby version matrix entry so integration test containers can coexist in parallel

## Issue Linkage

- Fixes #9

## Testing

- markdownlint
- `bundle exec rake`

## Notes

- -