### PR TITLE
refactor(rubocop): remove test exclusions and refactor oversized test classes

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,12 +18,10 @@ Metrics/AbcSize:
   Max: 30
   CountRepeatedAttributes: false
   Exclude:
-    - "test/**/*"
     - "lib/mq/rest/admin/session.rb"
 
 Metrics/BlockLength:
   Exclude:
-    - "test/**/*"
     - "lib/mq/rest/admin/mapping.rb"
 
 Metrics/BlockNesting:
@@ -37,7 +35,6 @@ Metrics/ClassLength:
     - array
     - hash
   Exclude:
-    - "test/**/*"
     - "lib/mq/rest/admin/session.rb"
 
 Metrics/CyclomaticComplexity:
@@ -50,7 +47,6 @@ Metrics/MethodLength:
     - array
     - hash
   Exclude:
-    - "test/**/*"
     - "lib/mq/rest/admin/session.rb"
     - "lib/mq/rest/admin/mapping.rb"
 

--- a/test/mq/rest/admin/mapping_test.rb
+++ b/test/mq/rest/admin/mapping_test.rb
@@ -163,6 +163,26 @@ module MQ
 
           assert_equal 'val', result['key']
         end
+      end
+
+      class MappingResponseTest < Minitest::Test
+        def setup
+          @mapping_data = {
+            'qualifiers' => {
+              'test_qualifier' => {
+                'request_key_map' => { 'snake_name' => 'MQSC_NAME' },
+                'request_value_map' => { 'snake_name' => { 'snake_val' => 'MQSC_VAL' } },
+                'request_key_value_map' => {
+                  'compound_attr' => {
+                    'opt_a' => { 'key' => 'MQSC_KEY_A', 'value' => 'MQSC_VALUE_A' }
+                  }
+                },
+                'response_key_map' => { 'MQSC_NAME' => 'snake_name', 'MQSC_OTHER' => 'other_name' },
+                'response_value_map' => { 'MQSC_NAME' => { 'MQSC_VAL' => 'snake_val' } }
+              }
+            }
+          }
+        end
 
         def test_map_response_key
           result = Mapping.map_response_attributes(

--- a/test/mq/rest/admin/session_test.rb
+++ b/test/mq/rest/admin/session_test.rb
@@ -295,9 +295,9 @@ module MQ
           # display commands should have responseParameters but no parameters
           refute payload.key?('parameters')
         end
+      end
 
-        # --- Mapping-enabled tests ---
-
+      class SessionMappingTest < Minitest::Test
         def test_map_attributes_enabled
           body = Admin.build_response([{ 'DESCR' => 'test queue' }])
           session, = Admin.build_test_session(
@@ -669,9 +669,9 @@ module MQ
 
           assert_kind_of Array, result
         end
+      end
 
-        # --- Private method coverage for hard-to-reach paths ---
-
+      class SessionInternalsTest < Minitest::Test
         def test_resolve_mapping_qualifier_downcase_fallback
           transport = MockTransport.new
           session = Session.new(

--- a/test/mq/rest/admin/transport_test.rb
+++ b/test/mq/rest/admin/transport_test.rb
@@ -23,6 +23,21 @@ module MQ
       end
 
       class NetHTTPTransportTest < Minitest::Test
+        def create_self_signed_cert
+          require 'openssl'
+          key = OpenSSL::PKey::RSA.new(2048)
+          cert = OpenSSL::X509::Certificate.new
+          cert.version = 2
+          cert.serial = 1
+          cert.subject = OpenSSL::X509::Name.new([%w[CN test]])
+          cert.issuer = cert.subject
+          cert.not_before = Time.now
+          cert.not_after = Time.now + 3600
+          cert.public_key = key.public_key
+          cert.sign(key, OpenSSL::Digest.new('SHA256'))
+          [cert, key]
+        end
+
         def setup
           @server = WEBrick::HTTPServer.new(
             Port: 0,
@@ -174,19 +189,8 @@ module MQ
         end
 
         def test_client_cert_and_key
-          require 'openssl'
           require 'tempfile'
-
-          key = OpenSSL::PKey::RSA.new(2048)
-          cert = OpenSSL::X509::Certificate.new
-          cert.version = 2
-          cert.serial = 1
-          cert.subject = OpenSSL::X509::Name.new([%w[CN test]])
-          cert.issuer = cert.subject
-          cert.not_before = Time.now
-          cert.not_after = Time.now + 3600
-          cert.public_key = key.public_key
-          cert.sign(key, OpenSSL::Digest.new('SHA256'))
+          cert, key = create_self_signed_cert
 
           cert_file = Tempfile.new(['cert', '.pem'])
           key_file = Tempfile.new(['key', '.pem'])
@@ -213,19 +217,8 @@ module MQ
         end
 
         def test_client_cert_without_key
-          require 'openssl'
           require 'tempfile'
-
-          key = OpenSSL::PKey::RSA.new(2048)
-          cert = OpenSSL::X509::Certificate.new
-          cert.version = 2
-          cert.serial = 1
-          cert.subject = OpenSSL::X509::Name.new([%w[CN test]])
-          cert.issuer = cert.subject
-          cert.not_before = Time.now
-          cert.not_after = Time.now + 3600
-          cert.public_key = key.public_key
-          cert.sign(key, OpenSSL::Digest.new('SHA256'))
+          cert, = create_self_signed_cert
 
           cert_file = Tempfile.new(['cert', '.pem'])
           begin


### PR DESCRIPTION
# Pull Request

## Summary

- Remove test exclusions from Metrics cops and refactor oversized test classes

## Issue Linkage

- Fixes #19

## Testing

- markdownlint
- `bundle exec rake`

## Notes

- -