### PR TITLE
refactor(rubocop): remove remaining .rubocop.yml relaxations for session.rb and mapping.rb

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,16 +17,6 @@ Layout/LineLength:
 Metrics/AbcSize:
   Max: 30
   CountRepeatedAttributes: false
-  Exclude:
-    - "lib/mq/rest/admin/session.rb"
-
-Metrics/BlockLength:
-  Exclude:
-    - "lib/mq/rest/admin/mapping.rb"
-
-Metrics/BlockNesting:
-  Exclude:
-    - "lib/mq/rest/admin/mapping.rb"
 
 Metrics/ClassLength:
   Max: 250
@@ -34,8 +24,6 @@ Metrics/ClassLength:
     - heredoc
     - array
     - hash
-  Exclude:
-    - "lib/mq/rest/admin/session.rb"
 
 Metrics/CyclomaticComplexity:
   Max: 12
@@ -46,9 +34,6 @@ Metrics/MethodLength:
     - heredoc
     - array
     - hash
-  Exclude:
-    - "lib/mq/rest/admin/session.rb"
-    - "lib/mq/rest/admin/mapping.rb"
 
 Metrics/ModuleLength:
   Max: 200
@@ -68,11 +53,6 @@ Metrics/PerceivedComplexity:
 
 Minitest/MultipleAssertions:
   Enabled: false
-
-Naming/PredicatePrefix:
-  AllowedMethods:
-    - has_error_codes?
-    - has_status?
 
 Style/Documentation:
   Enabled: true

--- a/lib/mq/rest/admin.rb
+++ b/lib/mq/rest/admin.rb
@@ -10,6 +10,7 @@ require_relative 'admin/mapping_merge'
 require_relative 'admin/commands'
 require_relative 'admin/ensure'
 require_relative 'admin/sync'
+require_relative 'admin/session_helpers'
 require_relative 'admin/session'
 
 # Top-level namespace for the MQ REST Admin library.

--- a/lib/mq/rest/admin/mapping.rb
+++ b/lib/mq/rest/admin/mapping.rb
@@ -219,47 +219,63 @@ module MQ
           issues = []
 
           attributes.each do |attr_name, attr_value|
-            if direction == 'request'
-              kvm_for_key = key_value_map[attr_name]
-              if kvm_for_key && !kvm_for_key.empty?
-                if attr_value.is_a?(String)
-                  mapping = kvm_for_key[attr_value]
-                  if mapping && mapping['key'] && mapping['value']
-                    mapped[mapping['key']] = mapping['value']
-                    next
-                  end
-                end
-                issues << MappingIssue.new(
-                  direction: direction, reason: 'unknown_value',
-                  attribute_name: attr_name, attribute_value: attr_value,
-                  object_index: object_index, qualifier: qualifier
-                )
-                mapped[attr_name] = attr_value
-                next
-              end
-            end
-
-            mapped_key = key_map[attr_name]
-            if mapped_key.nil?
-              issues << MappingIssue.new(
-                direction: direction, reason: 'unknown_key',
-                attribute_name: attr_name, attribute_value: attr_value,
-                object_index: object_index, qualifier: qualifier
-              )
-              mapped[attr_name] = attr_value
+            kvm_result = map_key_value_attribute(
+              attr_name, attr_value, key_value_map,
+              direction: direction, object_index: object_index, qualifier: qualifier
+            )
+            if kvm_result
+              mapped[kvm_result[0]] = kvm_result[1]
+              issues << kvm_result[2] if kvm_result[2]
               next
             end
-
-            mapped_value, value_issues = map_value(
-              qualifier: qualifier, attribute_name: attr_name,
-              attribute_value: attr_value, value_map: value_map,
-              direction: direction, object_index: object_index
+            map_single_attribute(
+              attr_name, attr_value, mapped, issues,
+              key_map: key_map, value_map: value_map,
+              qualifier: qualifier, direction: direction, object_index: object_index
             )
-            mapped[mapped_key] = mapped_value
-            issues.concat(value_issues)
           end
 
           [mapped, issues]
+        end
+
+        def map_key_value_attribute(attr_name, attr_value, key_value_map, direction:, object_index:, qualifier:)
+          return nil unless direction == 'request'
+
+          kvm_for_key = key_value_map[attr_name]
+          return nil unless kvm_for_key && !kvm_for_key.empty?
+
+          if attr_value.is_a?(String)
+            mapping = kvm_for_key[attr_value]
+            return [mapping['key'], mapping['value'], nil] if mapping && mapping['key'] && mapping['value']
+          end
+
+          issue = MappingIssue.new(
+            direction: direction, reason: 'unknown_value',
+            attribute_name: attr_name, attribute_value: attr_value,
+            object_index: object_index, qualifier: qualifier
+          )
+          [attr_name, attr_value, issue]
+        end
+
+        def map_single_attribute(attr_name, attr_value, mapped, issues, key_map:, value_map:, qualifier:,
+                                 direction:, object_index:)
+          mapped_key = key_map[attr_name]
+          if mapped_key.nil?
+            issues << MappingIssue.new(
+              direction: direction, reason: 'unknown_key',
+              attribute_name: attr_name, attribute_value: attr_value,
+              object_index: object_index, qualifier: qualifier
+            )
+            mapped[attr_name] = attr_value
+            return
+          end
+          mapped_value, value_issues = map_value(
+            qualifier: qualifier, attribute_name: attr_name,
+            attribute_value: attr_value, value_map: value_map,
+            direction: direction, object_index: object_index
+          )
+          mapped[mapped_key] = mapped_value
+          issues.concat(value_issues)
         end
 
         def map_value(qualifier:, attribute_name:, attribute_value:, value_map:, direction:, object_index:)
@@ -319,7 +335,9 @@ module MQ
 
         private_class_method :get_qualifier_data, :get_key_map, :get_value_map, :get_key_value_map,
                              :handle_unknown_qualifier, :handle_unknown_qualifier_list,
-                             :map_attributes, :map_attributes_internal, :map_value, :map_value_list
+                             :map_attributes, :map_attributes_internal,
+                             :map_key_value_attribute, :map_single_attribute,
+                             :map_value, :map_value_list
       end
     end
   end

--- a/lib/mq/rest/admin/session.rb
+++ b/lib/mq/rest/admin/session.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require 'base64'
-require 'json'
-
 module MQ
   module REST
     module Admin
@@ -50,6 +47,7 @@ module MQ
         include Commands
         include Ensure
         include Sync
+        include SessionHelpers
 
         # @return [String] the queue manager name
         attr_reader :qmgr_name
@@ -165,6 +163,15 @@ module MQ
           )
           @last_command_payload = payload.dup
 
+          response_payload = execute_transport_request(payload)
+          extract_result_objects(response_payload, mapping_qualifier, do_map)
+        end
+
+        def build_mqsc_url
+          "#{@rest_base_url}/admin/action/qmgr/#{@qmgr_name}/mqsc"
+        end
+
+        def execute_transport_request(payload)
           transport_response = @transport.post_json(
             build_mqsc_url, payload,
             headers: build_headers,
@@ -177,7 +184,10 @@ module MQ
           response_payload = parse_response_payload(transport_response.body)
           @last_response_payload = response_payload
           raise_for_command_errors(response_payload, transport_response.status_code)
+          response_payload
+        end
 
+        def extract_result_objects(response_payload, mapping_qualifier, do_map)
           command_response = extract_command_response(response_payload)
           parameter_objects = command_response.map do |item|
             params = item['parameters']
@@ -197,10 +207,6 @@ module MQ
           parameter_objects
         end
 
-        def build_mqsc_url
-          "#{@rest_base_url}/admin/action/qmgr/#{@qmgr_name}/mqsc"
-        end
-
         def build_headers
           headers = { 'Accept' => 'application/json' }
           if @credentials.is_a?(BasicAuth)
@@ -215,65 +221,10 @@ module MQ
           headers
         end
 
-        def build_basic_auth_header(username, password)
-          token = Base64.strict_encode64("#{username}:#{password}")
-          "Basic #{token}"
-        end
-
-        def build_command_payload(command:, qualifier:, name:, request_parameters:, response_parameters:)
-          payload = {
-            'type' => 'runCommandJSON',
-            'command' => command,
-            'qualifier' => qualifier
-          }
-          payload['name'] = name if name && !name.empty?
-          payload['parameters'] = request_parameters unless request_parameters.empty?
-          payload['responseParameters'] = response_parameters unless response_parameters.empty?
-          payload
-        end
-
-        def normalize_response_parameters(response_parameters, is_display: true)
-          if response_parameters.nil?
-            return is_display ? DEFAULT_RESPONSE_PARAMETERS.dup : []
-          end
-
-          params = response_parameters.to_a
-          return DEFAULT_RESPONSE_PARAMETERS.dup if all_response_parameters?(params)
-
-          params
-        end
-
-        def all_response_parameters?(response_parameters)
-          response_parameters.any? { |p| p.downcase == 'all' }
-        end
-
-        def parse_response_payload(response_text)
-          decoded = JSON.parse(response_text)
-          unless decoded.is_a?(Hash)
-            raise ResponseError.new('Response payload was not a JSON object.', response_text: response_text)
-          end
-
-          decoded
-        rescue JSON::ParserError
-          raise ResponseError.new('Response body was not valid JSON.', response_text: response_text)
-        end
-
-        def extract_command_response(payload)
-          command_response = payload['commandResponse']
-          return [] if command_response.nil?
-
-          raise ResponseError, 'Response commandResponse was not a list.' unless command_response.is_a?(Array)
-
-          command_response.each do |item|
-            raise ResponseError, 'Response commandResponse item was not an object.' unless item.is_a?(Hash)
-          end
-          command_response
-        end
-
         def raise_for_command_errors(payload, status_code)
           overall_cc = extract_optional_int(payload['overallCompletionCode'])
           overall_rc = extract_optional_int(payload['overallReasonCode'])
-          has_overall = has_error_codes?(overall_cc, overall_rc)
+          has_overall = error_codes?(overall_cc, overall_rc)
 
           command_issues = []
           command_response = payload['commandResponse']
@@ -283,7 +234,7 @@ module MQ
 
               cc = extract_optional_int(item['completionCode'])
               rc = extract_optional_int(item['reasonCode'])
-              next unless has_error_codes?(cc, rc)
+              next unless error_codes?(cc, rc)
 
               command_issues << "index=#{idx} completionCode=#{cc} reasonCode=#{rc}"
             end
@@ -303,34 +254,6 @@ module MQ
           )
         end
 
-        def extract_optional_int(value)
-          value.is_a?(Integer) ? value : nil
-        end
-
-        def has_error_codes?(completion_code, reason_code)
-          (completion_code && completion_code != 0) || (reason_code && reason_code != 0)
-        end
-
-        def flatten_nested_objects(parameter_objects)
-          flattened = []
-          parameter_objects.each do |item|
-            objects = item['objects']
-            if objects.is_a?(Array)
-              shared = item.except('objects')
-              objects.each do |nested|
-                flattened << shared.merge(nested) if nested.is_a?(Hash)
-              end
-            else
-              flattened << item
-            end
-          end
-          flattened
-        end
-
-        def normalize_response_attributes(attributes)
-          attributes.transform_keys(&:upcase)
-        end
-
         def resolve_mapping_qualifier(command, mqsc_qualifier)
           command_map = get_command_map(@mapping_data)
           command_key = "#{command} #{mqsc_qualifier}"
@@ -343,11 +266,6 @@ module MQ
           return fallback unless fallback.nil?
 
           mqsc_qualifier.downcase
-        end
-
-        def get_command_map(mapping_data)
-          commands = mapping_data['commands']
-          commands.is_a?(Hash) ? commands : {}
         end
 
         def map_response_parameters(command, mqsc_qualifier, mapping_qualifier, response_parameters)
@@ -371,23 +289,6 @@ module MQ
           raise MappingError, issues if @mapping_strict && !issues.empty?
 
           mapped
-        end
-
-        def get_response_parameter_macros(command, mqsc_qualifier, mapping_data:)
-          command_key = "#{command} #{mqsc_qualifier}"
-          commands = get_command_map(mapping_data)
-          entry = commands[command_key]
-          return [] unless entry.is_a?(Hash)
-
-          macros = entry['response_parameter_macros']
-          return [] unless macros.is_a?(Array)
-
-          macros.select { |m| m.is_a?(String) }
-        end
-
-        def build_unknown_qualifier_issue(qualifier)
-          [MappingIssue.new(direction: 'request', reason: 'unknown_qualifier', attribute_name: '*',
-                            qualifier: qualifier)]
         end
 
         def build_snake_to_mqsc_map(qualifier_entry)
@@ -442,36 +343,6 @@ module MQ
           end
 
           rest.empty? ? mapped_keyword : "#{mapped_keyword} #{rest}"
-        end
-
-        def map_response_parameter_names(response_parameters, macro_lookup, combined_map, mapping_qualifier)
-          mapped = []
-          issues = []
-          response_parameters.each do |name|
-            macro_key = macro_lookup[name.downcase]
-            if macro_key
-              mapped << macro_key
-              next
-            end
-            mapped_key = combined_map[name]
-            if mapped_key.nil?
-              issues << MappingIssue.new(
-                direction: 'request', reason: 'unknown_key',
-                attribute_name: name, qualifier: mapping_qualifier
-              )
-              mapped << name
-              next
-            end
-            mapped << mapped_key
-          end
-          [mapped, issues]
-        end
-
-        def get_qualifier_entry(qualifier, mapping_data:)
-          qualifiers = mapping_data['qualifiers']
-          return nil unless qualifiers.is_a?(Hash)
-
-          qualifiers[qualifier]
         end
 
         def resolve_mapping_data(overrides, mode)

--- a/lib/mq/rest/admin/session_helpers.rb
+++ b/lib/mq/rest/admin/session_helpers.rb
@@ -1,0 +1,154 @@
+# frozen_string_literal: true
+
+require 'base64'
+require 'json'
+
+module MQ
+  module REST
+    module Admin
+      # Pure-function helpers extracted from {Session} to reduce class length.
+      #
+      # All methods are private instance methods that do not depend on Session
+      # instance state — they operate only on their arguments and return values.
+      # Included by {Session}.
+      module SessionHelpers
+        private
+
+        def build_basic_auth_header(username, password)
+          token = Base64.strict_encode64("#{username}:#{password}")
+          "Basic #{token}"
+        end
+
+        def normalize_response_parameters(response_parameters, is_display: true)
+          if response_parameters.nil?
+            return is_display ? DEFAULT_RESPONSE_PARAMETERS.dup : []
+          end
+
+          params = response_parameters.to_a
+          return DEFAULT_RESPONSE_PARAMETERS.dup if all_response_parameters?(params)
+
+          params
+        end
+
+        def all_response_parameters?(response_parameters)
+          response_parameters.any? { |p| p.downcase == 'all' }
+        end
+
+        def parse_response_payload(response_text)
+          decoded = JSON.parse(response_text)
+          unless decoded.is_a?(Hash)
+            raise ResponseError.new('Response payload was not a JSON object.', response_text: response_text)
+          end
+
+          decoded
+        rescue JSON::ParserError
+          raise ResponseError.new('Response body was not valid JSON.', response_text: response_text)
+        end
+
+        def extract_command_response(payload)
+          command_response = payload['commandResponse']
+          return [] if command_response.nil?
+
+          raise ResponseError, 'Response commandResponse was not a list.' unless command_response.is_a?(Array)
+
+          command_response.each do |item|
+            raise ResponseError, 'Response commandResponse item was not an object.' unless item.is_a?(Hash)
+          end
+          command_response
+        end
+
+        def extract_optional_int(value)
+          value.is_a?(Integer) ? value : nil
+        end
+
+        def error_codes?(completion_code, reason_code)
+          (completion_code && completion_code != 0) || (reason_code && reason_code != 0)
+        end
+
+        def flatten_nested_objects(parameter_objects)
+          flattened = []
+          parameter_objects.each do |item|
+            objects = item['objects']
+            if objects.is_a?(Array)
+              shared = item.except('objects')
+              objects.each do |nested|
+                flattened << shared.merge(nested) if nested.is_a?(Hash)
+              end
+            else
+              flattened << item
+            end
+          end
+          flattened
+        end
+
+        def normalize_response_attributes(attributes)
+          attributes.transform_keys(&:upcase)
+        end
+
+        def build_command_payload(command:, qualifier:, name:, request_parameters:, response_parameters:)
+          payload = {
+            'type' => 'runCommandJSON',
+            'command' => command,
+            'qualifier' => qualifier
+          }
+          payload['name'] = name if name && !name.empty?
+          payload['parameters'] = request_parameters unless request_parameters.empty?
+          payload['responseParameters'] = response_parameters unless response_parameters.empty?
+          payload
+        end
+
+        def get_command_map(mapping_data)
+          commands = mapping_data['commands']
+          commands.is_a?(Hash) ? commands : {}
+        end
+
+        def get_response_parameter_macros(command, mqsc_qualifier, mapping_data:)
+          command_key = "#{command} #{mqsc_qualifier}"
+          commands = get_command_map(mapping_data)
+          entry = commands[command_key]
+          return [] unless entry.is_a?(Hash)
+
+          macros = entry['response_parameter_macros']
+          return [] unless macros.is_a?(Array)
+
+          macros.select { |m| m.is_a?(String) }
+        end
+
+        def build_unknown_qualifier_issue(qualifier)
+          [MappingIssue.new(direction: 'request', reason: 'unknown_qualifier', attribute_name: '*',
+                            qualifier: qualifier)]
+        end
+
+        def map_response_parameter_names(response_parameters, macro_lookup, combined_map, mapping_qualifier)
+          mapped = []
+          issues = []
+          response_parameters.each do |name|
+            macro_key = macro_lookup[name.downcase]
+            if macro_key
+              mapped << macro_key
+              next
+            end
+            mapped_key = combined_map[name]
+            if mapped_key.nil?
+              issues << MappingIssue.new(
+                direction: 'request', reason: 'unknown_key',
+                attribute_name: name, qualifier: mapping_qualifier
+              )
+              mapped << name
+              next
+            end
+            mapped << mapped_key
+          end
+          [mapped, issues]
+        end
+
+        def get_qualifier_entry(qualifier, mapping_data:)
+          qualifiers = mapping_data['qualifiers']
+          return nil unless qualifiers.is_a?(Hash)
+
+          qualifiers[qualifier]
+        end
+      end
+    end
+  end
+end

--- a/lib/mq/rest/admin/sync.rb
+++ b/lib/mq/rest/admin/sync.rb
@@ -184,7 +184,7 @@ module MQ
               name: name, request_parameters: nil, response_parameters: ['all']
             )
             polls += 1
-            if has_status?(status_rows, obj_config.status_keys, RUNNING_VALUES)
+            if status?(status_rows, obj_config.status_keys, RUNNING_VALUES)
               elapsed = clock_now - start_time
               return SyncResult.new(operation: :started, polls: polls, elapsed_seconds: elapsed)
             end
@@ -217,7 +217,7 @@ module MQ
               elapsed = clock_now - start_time
               return SyncResult.new(operation: :stopped, polls: polls, elapsed_seconds: elapsed)
             end
-            if has_status?(status_rows, obj_config.status_keys, STOPPED_VALUES)
+            if status?(status_rows, obj_config.status_keys, STOPPED_VALUES)
               elapsed = clock_now - start_time
               return SyncResult.new(operation: :stopped, polls: polls, elapsed_seconds: elapsed)
             end
@@ -241,7 +241,7 @@ module MQ
           )
         end
 
-        def has_status?(rows, status_keys, target_values)
+        def status?(rows, status_keys, target_values)
           rows.any? do |row|
             status_keys.any? do |key|
               value = row[key]

--- a/sig/mq/rest/admin/mapping.rbs
+++ b/sig/mq/rest/admin/mapping.rbs
@@ -68,6 +68,8 @@ module MQ
         def handle_unknown_qualifier_list: (String qualifier, Array[Hash[String, untyped]] objects, direction: String, strict: bool) -> Array[Hash[String, untyped]]
         def map_attributes: (qualifier: String, attributes: Hash[String, untyped], key_map: Hash[String, String], key_value_map: Hash[String, untyped], value_map: Hash[String, untyped], direction: String, strict: bool) -> Hash[String, untyped]
         def map_attributes_internal: (qualifier: String, attributes: Hash[String, untyped], key_map: Hash[String, String], key_value_map: Hash[String, untyped], value_map: Hash[String, untyped], direction: String, object_index: Integer?) -> [Hash[String, untyped], Array[MappingIssue]]
+        def map_key_value_attribute: (String attr_name, untyped attr_value, Hash[String, untyped] key_value_map, direction: String, object_index: Integer?, qualifier: String) -> [String, untyped, MappingIssue?]?
+        def map_single_attribute: (String attr_name, untyped attr_value, Hash[String, untyped] mapped, Array[MappingIssue] issues, key_map: Hash[String, String], value_map: Hash[String, untyped], qualifier: String, direction: String, object_index: Integer?) -> void
         def map_value: (qualifier: String, attribute_name: String, attribute_value: untyped, value_map: Hash[String, untyped], direction: String, object_index: Integer?) -> [untyped, Array[MappingIssue]]
         def map_value_list: (qualifier: String, attribute_name: String, attribute_values: Array[untyped], value_mappings: Hash[String, untyped], direction: String, object_index: Integer?) -> [Array[untyped], Array[MappingIssue]]
       end

--- a/sig/mq/rest/admin/session.rbs
+++ b/sig/mq/rest/admin/session.rbs
@@ -10,6 +10,7 @@ module MQ
         include Commands
         include Ensure
         include Sync
+        include SessionHelpers
 
         attr_reader qmgr_name: String
         attr_reader gateway_qmgr: String?
@@ -45,33 +46,14 @@ module MQ
         ) -> Array[Hash[String, untyped]]
 
         def build_mqsc_url: () -> String
+        def execute_transport_request: (Hash[String, untyped] payload) -> Hash[String, untyped]
+        def extract_result_objects: (Hash[String, untyped] response_payload, String mapping_qualifier, bool do_map) -> Array[Hash[String, untyped]]
         def build_headers: () -> Hash[String, String]
-        def build_basic_auth_header: (String username, String password) -> String
-        def build_command_payload: (
-          command: String,
-          qualifier: String,
-          name: String?,
-          request_parameters: untyped,
-          response_parameters: untyped
-        ) -> Hash[String, untyped]
-        def normalize_response_parameters: (Array[String]? response_parameters, ?is_display: bool) -> Array[String]
-        def all_response_parameters?: (Array[String] response_parameters) -> bool
-        def parse_response_payload: (String response_text) -> Hash[String, untyped]
-        def extract_command_response: (Hash[String, untyped] payload) -> Array[Hash[String, untyped]]
         def raise_for_command_errors: (Hash[String, untyped] payload, Integer status_code) -> void
-        def extract_optional_int: (untyped value) -> Integer?
-        def has_error_codes?: (Integer? completion_code, Integer? reason_code) -> bool
-        def flatten_nested_objects: (Array[Hash[String, untyped]] parameter_objects) -> Array[Hash[String, untyped]]
-        def normalize_response_attributes: (Hash[String, untyped] attributes) -> Hash[String, untyped]
         def resolve_mapping_qualifier: (String command, String mqsc_qualifier) -> String
-        def get_command_map: (Hash[String, untyped] mapping_data) -> Hash[String, untyped]
         def map_response_parameters: (String command, String mqsc_qualifier, String mapping_qualifier, Array[String] response_parameters) -> Array[String]
-        def get_response_parameter_macros: (String command, String mqsc_qualifier, mapping_data: Hash[String, untyped]) -> Array[String]
-        def build_unknown_qualifier_issue: (String qualifier) -> Array[MappingIssue]
         def build_snake_to_mqsc_map: (Hash[String, untyped] qualifier_entry) -> Hash[String, String]
         def map_where_keyword: (String where, String mapping_qualifier, strict: bool, mapping_data: Hash[String, untyped]) -> String
-        def map_response_parameter_names: (Array[String] response_parameters, Hash[String, String] macro_lookup, Hash[String, String] combined_map, String mapping_qualifier) -> [Array[String], Array[MappingIssue]]
-        def get_qualifier_entry: (String qualifier, mapping_data: Hash[String, untyped]) -> Hash[String, untyped]?
         def resolve_mapping_data: (Hash[String, untyped]? overrides, Symbol mode) -> Hash[String, untyped]
         def resolve_transport: (credentials credentials, NetHTTPTransport? transport) -> NetHTTPTransport
       end

--- a/sig/mq/rest/admin/session_helpers.rbs
+++ b/sig/mq/rest/admin/session_helpers.rbs
@@ -1,0 +1,31 @@
+module MQ
+  module REST
+    module Admin
+      module SessionHelpers
+        private
+
+        def build_basic_auth_header: (String username, String password) -> String
+        def normalize_response_parameters: (Array[String]? response_parameters, ?is_display: bool) -> Array[String]
+        def all_response_parameters?: (Array[String] response_parameters) -> bool
+        def parse_response_payload: (String response_text) -> Hash[String, untyped]
+        def extract_command_response: (Hash[String, untyped] payload) -> Array[Hash[String, untyped]]
+        def extract_optional_int: (untyped value) -> Integer?
+        def error_codes?: (Integer? completion_code, Integer? reason_code) -> bool
+        def flatten_nested_objects: (Array[Hash[String, untyped]] parameter_objects) -> Array[Hash[String, untyped]]
+        def normalize_response_attributes: (Hash[String, untyped] attributes) -> Hash[String, untyped]
+        def build_command_payload: (
+          command: String,
+          qualifier: String,
+          name: String?,
+          request_parameters: untyped,
+          response_parameters: untyped
+        ) -> Hash[String, untyped]
+        def get_command_map: (Hash[String, untyped] mapping_data) -> Hash[String, untyped]
+        def get_response_parameter_macros: (String command, String mqsc_qualifier, mapping_data: Hash[String, untyped]) -> Array[String]
+        def build_unknown_qualifier_issue: (String qualifier) -> Array[MappingIssue]
+        def map_response_parameter_names: (Array[String] response_parameters, Hash[String, String] macro_lookup, Hash[String, String] combined_map, String mapping_qualifier) -> [Array[String], Array[MappingIssue]]
+        def get_qualifier_entry: (String qualifier, mapping_data: Hash[String, untyped]) -> Hash[String, untyped]?
+      end
+    end
+  end
+end

--- a/sig/mq/rest/admin/sync.rbs
+++ b/sig/mq/rest/admin/sync.rbs
@@ -69,7 +69,7 @@ module MQ
         def start_and_poll: (String name, ObjectTypeConfig obj_config, SyncConfig? config) -> SyncResult
         def stop_and_poll: (String name, ObjectTypeConfig obj_config, SyncConfig? config) -> SyncResult
         def do_restart: (String name, ObjectTypeConfig obj_config, SyncConfig? config) -> SyncResult
-        def has_status?: (Array[Hash[String, untyped]] rows, Array[String] status_keys, Set[String] target_values) -> bool
+        def status?: (Array[Hash[String, untyped]] rows, Array[String] status_keys, Set[String] target_values) -> bool
         def clock_now: () -> Float
         def sleep_interval: (Float seconds) -> void
       end


### PR DESCRIPTION
# Pull Request

## Summary

- Remove remaining .rubocop.yml relaxations for session.rb and mapping.rb

## Issue Linkage

- Fixes #19

## Testing

- markdownlint
- `bundle exec rake`

## Notes

- -