### PR TITLE
chore(rubocop): enable Minitest/MultipleAssertions cop with Max: 8

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -52,7 +52,7 @@ Metrics/PerceivedComplexity:
   Max: 12
 
 Minitest/MultipleAssertions:
-  Enabled: false
+  Max: 8
 
 Style/Documentation:
   Enabled: true


### PR DESCRIPTION
# Pull Request

## Summary

- Enable Minitest/MultipleAssertions cop with Max: 8

## Issue Linkage

- Fixes #19

## Testing

- markdownlint
- `bundle exec rake`

## Notes

- -