### PR TITLE
chore: sync cliff-release-notes.toml template fix and markdownlint relaxations

### DIFF
--- a/cliff-release-notes.toml
+++ b/cliff-release-notes.toml
@@ -11,7 +11,7 @@ body = """{% if version -%}
           {% if commit.body %}
           {{ commit.body | trim }}
           {% endif -%}
-    {% endfor -%}
+    {% endfor %}
 {% endfor %}
 """
 footer = ""

--- a/releases/.markdownlint.json
+++ b/releases/.markdownlint.json
@@ -4,5 +4,8 @@
   "MD013": false,
   "MD024": { "siblings_only": true },
   "MD032": false,
-  "MD041": false
+  "MD033": false,
+  "MD037": false,
+  "MD041": false,
+  "MD050": false
 }


### PR DESCRIPTION
# Pull Request

## Summary

- Sync template whitespace fix and additional markdownlint relaxations from Python repo

## Issue Linkage

- Fixes #39

## Testing

- markdownlint
- `bundle exec rake`

## Notes

- -