### PR TITLE
chore(docs): restructure Releases nav with navigation.indexes

### DIFF
--- a/docs/site/mkdocs.yml
+++ b/docs/site/mkdocs.yml
@@ -14,6 +14,7 @@ theme:
   features:
     - navigation.tabs
     - navigation.sections
+    - navigation.indexes
     - navigation.top
     - content.code.copy
     - search.highlight
@@ -60,8 +61,9 @@ markdown_extensions:
 nav:
   - Home: index.md
   - Releases:
-      - Release Notes: releases/index.md
       - Changelog: changelog.md
+      - Release Notes:
+          - releases/index.md
   - Getting Started: getting-started.md
   - Architecture: architecture.md
   - Examples: examples.md


### PR DESCRIPTION
# Pull Request

## Summary

- Restructure docs Releases nav with navigation.indexes

## Issue Linkage

- Fixes #41

## Testing

- markdownlint
- `bundle exec rake`

## Notes

- -