### PR TITLE
fix(docs): remove releases/index.md nav entry until first release exists

### DIFF
--- a/docs/site/mkdocs.yml
+++ b/docs/site/mkdocs.yml
@@ -66,8 +66,6 @@ nav:
       - Examples: examples.md
   - Releases:
       - Changelog: changelog.md
-      - Release Notes:
-          - releases/index.md
   - API Reference:
       - api/index.md
       - Session: api/session.md


### PR DESCRIPTION
# Pull Request

## Summary

- Remove releases/index.md nav reference that breaks docs build since no releases exist yet

## Issue Linkage

- Fixes #58

## Testing

- markdownlint
- `bundle exec rake`

## Notes

- -