### PR TITLE
ci: rename type-check job from test: to ci: prefix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
         run: bundle exec rake test
 
   type-check:
-    name: "test: type-check"
+    name: "ci: type-check"
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/wphillipmoore/dev-ruby:3.4


### PR DESCRIPTION
# Pull Request

## Summary

- Rename type-check job from test: to ci: prefix per standard-actions#110

## Issue Linkage

- Fixes #63

## Testing

- markdownlint
- `bundle exec rake`

## Notes

- -