### PR TITLE
refactor: rename 13 abbreviated and single-char variables to descriptive names

### DIFF
--- a/lib/mq/rest/admin/mapping.rb
+++ b/lib/mq/rest/admin/mapping.rb
@@ -51,8 +51,8 @@ module MQ
           case value
           when nil then nil
           when String, Integer, Float, true, false then value
-          when Array then value.map { |v| serialize_value(v) } # steep:ignore NoMethod
-          when Hash then value.transform_values { |v| serialize_value(v) } # steep:ignore NoMethod
+          when Array then value.map { |element| serialize_value(element) } # steep:ignore NoMethod
+          when Hash then value.transform_values { |hash_value| serialize_value(hash_value) } # steep:ignore NoMethod
           else value.inspect
           end
         end
@@ -174,8 +174,8 @@ module MQ
         end
 
         def get_key_value_map(qualifier_data, map_name)
-          kvm = qualifier_data[map_name]
-          kvm.is_a?(Hash) ? kvm : {}
+          key_value_map = qualifier_data[map_name]
+          key_value_map.is_a?(Hash) ? key_value_map : {}
         end
 
         def handle_unknown_qualifier(qualifier, attributes, direction:, strict:)

--- a/lib/mq/rest/admin/mapping_merge.rb
+++ b/lib/mq/rest/admin/mapping_merge.rb
@@ -86,7 +86,7 @@ module MQ
 
           return if missing_parts.empty?
 
-          detail = missing_parts.map { |e| "  #{e}" }.join("\n")
+          detail = missing_parts.map { |entry| "  #{entry}" }.join("\n")
           raise ArgumentError, "mapping_overrides is incomplete for REPLACE mode. Missing entries:\n#{detail}"
         end
 

--- a/lib/mq/rest/admin/session.rb
+++ b/lib/mq/rest/admin/session.rb
@@ -222,28 +222,30 @@ module MQ
         end
 
         def raise_for_command_errors(payload, status_code)
-          overall_cc = extract_optional_int(payload['overallCompletionCode'])
-          overall_rc = extract_optional_int(payload['overallReasonCode'])
-          has_overall = error_codes?(overall_cc, overall_rc)
+          overall_completion_code = extract_optional_int(payload['overallCompletionCode'])
+          overall_reason_code = extract_optional_int(payload['overallReasonCode'])
+          has_overall = error_codes?(overall_completion_code, overall_reason_code)
 
           command_issues = []
           command_response = payload['commandResponse']
           if command_response.is_a?(Array)
-            command_response.each_with_index do |item, idx|
+            command_response.each_with_index do |item, item_index|
               next unless item.is_a?(Hash)
 
-              cc = extract_optional_int(item['completionCode'])
-              rc = extract_optional_int(item['reasonCode'])
-              next unless error_codes?(cc, rc)
+              completion_code = extract_optional_int(item['completionCode'])
+              reason_code = extract_optional_int(item['reasonCode'])
+              next unless error_codes?(completion_code, reason_code)
 
-              command_issues << "index=#{idx} completionCode=#{cc} reasonCode=#{rc}"
+              command_issues << "index=#{item_index} completionCode=#{completion_code} reasonCode=#{reason_code}"
             end
           end
 
           return unless has_overall || !command_issues.empty?
 
           lines = ['MQ REST command failed.']
-          lines << "overallCompletionCode=#{overall_cc} overallReasonCode=#{overall_rc}" if has_overall
+          if has_overall
+            lines << "overallCompletionCode=#{overall_completion_code} overallReasonCode=#{overall_reason_code}"
+          end
           unless command_issues.empty?
             lines << 'commandResponse:'
             lines.concat(command_issues)
@@ -272,7 +274,7 @@ module MQ
           return response_parameters if all_response_parameters?(response_parameters)
 
           macros = get_response_parameter_macros(command, mqsc_qualifier, mapping_data: @mapping_data)
-          macro_lookup = macros.to_h { |m| [m.downcase, m] }
+          macro_lookup = macros.to_h { |macro| [macro.downcase, macro] }
 
           qualifier_entry = get_qualifier_entry(mapping_qualifier, mapping_data: @mapping_data)
           if qualifier_entry.nil?

--- a/lib/mq/rest/admin/session_helpers.rb
+++ b/lib/mq/rest/admin/session_helpers.rb
@@ -31,7 +31,7 @@ module MQ
         end
 
         def all_response_parameters?(response_parameters)
-          response_parameters.any? { |p| p.downcase == 'all' }
+          response_parameters.any? { |parameter| parameter.downcase == 'all' }
         end
 
         def parse_response_payload(response_text)

--- a/lib/mq/rest/admin/sync.rb
+++ b/lib/mq/rest/admin/sync.rb
@@ -170,7 +170,7 @@ module MQ
         private
 
         def start_and_poll(name, obj_config, config)
-          cfg = config || SyncConfig.new
+          sync_config = config || SyncConfig.new
           mqsc_command(
             command: 'START', mqsc_qualifier: obj_config.start_qualifier,
             name: name, request_parameters: nil, response_parameters: nil
@@ -178,7 +178,7 @@ module MQ
           polls = 0
           start_time = clock_now
           loop do
-            sleep_interval(cfg.poll_interval_seconds)
+            sleep_interval(sync_config.poll_interval_seconds)
             status_rows = mqsc_command(
               command: 'DISPLAY', mqsc_qualifier: obj_config.status_qualifier,
               name: name, request_parameters: nil, response_parameters: ['all']
@@ -189,17 +189,17 @@ module MQ
               return SyncResult.new(operation: :started, polls: polls, elapsed_seconds: elapsed)
             end
             elapsed = clock_now - start_time
-            next unless elapsed >= cfg.timeout_seconds
+            next unless elapsed >= sync_config.timeout_seconds
 
             raise TimeoutError.new(
-              "#{obj_config.start_qualifier} '#{name}' did not reach RUNNING within #{cfg.timeout_seconds}s",
+              "#{obj_config.start_qualifier} '#{name}' did not reach RUNNING within #{sync_config.timeout_seconds}s",
               name: name, operation: 'start', elapsed: elapsed
             )
           end
         end
 
         def stop_and_poll(name, obj_config, config)
-          cfg = config || SyncConfig.new
+          sync_config = config || SyncConfig.new
           mqsc_command(
             command: 'STOP', mqsc_qualifier: obj_config.stop_qualifier,
             name: name, request_parameters: nil, response_parameters: nil
@@ -207,7 +207,7 @@ module MQ
           polls = 0
           start_time = clock_now
           loop do
-            sleep_interval(cfg.poll_interval_seconds)
+            sleep_interval(sync_config.poll_interval_seconds)
             status_rows = mqsc_command(
               command: 'DISPLAY', mqsc_qualifier: obj_config.status_qualifier,
               name: name, request_parameters: nil, response_parameters: ['all']
@@ -222,10 +222,10 @@ module MQ
               return SyncResult.new(operation: :stopped, polls: polls, elapsed_seconds: elapsed)
             end
             elapsed = clock_now - start_time
-            next unless elapsed >= cfg.timeout_seconds
+            next unless elapsed >= sync_config.timeout_seconds
 
             raise TimeoutError.new(
-              "#{obj_config.stop_qualifier} '#{name}' did not reach STOPPED within #{cfg.timeout_seconds}s",
+              "#{obj_config.stop_qualifier} '#{name}' did not reach STOPPED within #{sync_config.timeout_seconds}s",
               name: name, operation: 'stop', elapsed: elapsed
             )
           end


### PR DESCRIPTION
# Pull Request

## Summary

- Rename 13 abbreviated and single-char variables to descriptive names for PBP compliance

## Issue Linkage

- Fixes #65

## Testing

- markdownlint
- `bundle exec rake`

## Notes

- -