### PR TITLE
fix: require name parameter for DELETE Q* methods

### DIFF
--- a/lib/mq/rest/admin/commands.rb
+++ b/lib/mq/rest/admin/commands.rb
@@ -948,13 +948,13 @@ module MQ
 
         # Execute the MQSC +DELETE QALIAS+ command.
         #
-        # @param name [String, nil] object name
+        # @param name [String] the object name
         # @param request_parameters [Hash{String => Object}, nil] request attributes
         # @param response_parameters [Array<String>, nil] response attributes to return
         # @return [nil]
         # @raise [CommandError] if the MQSC command fails
         # @raise [MappingError] if attribute mapping fails in strict mode
-        def delete_qalias(name: nil, request_parameters: nil, response_parameters: nil)
+        def delete_qalias(name, request_parameters: nil, response_parameters: nil)
           mqsc_command(
             command: 'DELETE', mqsc_qualifier: 'QALIAS',
             name: name, request_parameters: request_parameters,
@@ -965,13 +965,13 @@ module MQ
 
         # Execute the MQSC +DELETE QLOCAL+ command.
         #
-        # @param name [String, nil] object name
+        # @param name [String] the object name
         # @param request_parameters [Hash{String => Object}, nil] request attributes
         # @param response_parameters [Array<String>, nil] response attributes to return
         # @return [nil]
         # @raise [CommandError] if the MQSC command fails
         # @raise [MappingError] if attribute mapping fails in strict mode
-        def delete_qlocal(name: nil, request_parameters: nil, response_parameters: nil)
+        def delete_qlocal(name, request_parameters: nil, response_parameters: nil)
           mqsc_command(
             command: 'DELETE', mqsc_qualifier: 'QLOCAL',
             name: name, request_parameters: request_parameters,
@@ -982,13 +982,13 @@ module MQ
 
         # Execute the MQSC +DELETE QMODEL+ command.
         #
-        # @param name [String, nil] object name
+        # @param name [String] the object name
         # @param request_parameters [Hash{String => Object}, nil] request attributes
         # @param response_parameters [Array<String>, nil] response attributes to return
         # @return [nil]
         # @raise [CommandError] if the MQSC command fails
         # @raise [MappingError] if attribute mapping fails in strict mode
-        def delete_qmodel(name: nil, request_parameters: nil, response_parameters: nil)
+        def delete_qmodel(name, request_parameters: nil, response_parameters: nil)
           mqsc_command(
             command: 'DELETE', mqsc_qualifier: 'QMODEL',
             name: name, request_parameters: request_parameters,
@@ -999,13 +999,13 @@ module MQ
 
         # Execute the MQSC +DELETE QREMOTE+ command.
         #
-        # @param name [String, nil] object name
+        # @param name [String] the object name
         # @param request_parameters [Hash{String => Object}, nil] request attributes
         # @param response_parameters [Array<String>, nil] response attributes to return
         # @return [nil]
         # @raise [CommandError] if the MQSC command fails
         # @raise [MappingError] if attribute mapping fails in strict mode
-        def delete_qremote(name: nil, request_parameters: nil, response_parameters: nil)
+        def delete_qremote(name, request_parameters: nil, response_parameters: nil)
           mqsc_command(
             command: 'DELETE', mqsc_qualifier: 'QREMOTE',
             name: name, request_parameters: request_parameters,

--- a/lib/mq/rest/admin/mapping-data.json
+++ b/lib/mq/rest/admin/mapping-data.json
@@ -172,16 +172,20 @@
       "qualifier": "psid"
     },
     "DELETE QALIAS": {
-      "qualifier": "queue"
+      "qualifier": "queue",
+      "name_required": true
     },
     "DELETE QLOCAL": {
-      "qualifier": "queue"
+      "qualifier": "queue",
+      "name_required": true
     },
     "DELETE QMODEL": {
-      "qualifier": "queue"
+      "qualifier": "queue",
+      "name_required": true
     },
     "DELETE QREMOTE": {
-      "qualifier": "queue"
+      "qualifier": "queue",
+      "name_required": true
     },
     "DELETE QUEUE": {
       "qualifier": "queue",

--- a/sig/mq/rest/admin/commands.rbs
+++ b/sig/mq/rest/admin/commands.rbs
@@ -140,10 +140,10 @@ module MQ
         def delete_policy: (?name: String?, ?request_parameters: request_params, ?response_parameters: response_params) -> nil
         def delete_process: (?name: String?, ?request_parameters: request_params, ?response_parameters: response_params) -> nil
         def delete_psid: (?name: String?, ?request_parameters: request_params, ?response_parameters: response_params) -> nil
-        def delete_qalias: (?name: String?, ?request_parameters: request_params, ?response_parameters: response_params) -> nil
-        def delete_qlocal: (?name: String?, ?request_parameters: request_params, ?response_parameters: response_params) -> nil
-        def delete_qmodel: (?name: String?, ?request_parameters: request_params, ?response_parameters: response_params) -> nil
-        def delete_qremote: (?name: String?, ?request_parameters: request_params, ?response_parameters: response_params) -> nil
+        def delete_qalias: (String name, ?request_parameters: request_params, ?response_parameters: response_params) -> nil
+        def delete_qlocal: (String name, ?request_parameters: request_params, ?response_parameters: response_params) -> nil
+        def delete_qmodel: (String name, ?request_parameters: request_params, ?response_parameters: response_params) -> nil
+        def delete_qremote: (String name, ?request_parameters: request_params, ?response_parameters: response_params) -> nil
         def delete_service: (?name: String?, ?request_parameters: request_params, ?response_parameters: response_params) -> nil
         def delete_stgclass: (?name: String?, ?request_parameters: request_params, ?response_parameters: response_params) -> nil
         def delete_sub: (?name: String?, ?request_parameters: request_params, ?response_parameters: response_params) -> nil

--- a/test/integration/mq_integration_test.rb
+++ b/test/integration/mq_integration_test.rb
@@ -127,6 +127,7 @@ end
 # Methods that take name as a positional (non-keyword) argument.
 POSITIONAL_NAME_METHODS = %i[
   define_qlocal define_qremote define_qalias define_qmodel define_channel
+  delete_qlocal delete_qremote delete_qalias delete_qmodel
   delete_queue delete_channel
   display_listener display_namelist display_process display_topic display_qstatus
   ensure_qlocal ensure_qremote ensure_qalias ensure_qmodel ensure_channel
@@ -329,7 +330,7 @@ class MqIntegrationTest < Minitest::Test
 
     # Clean up from any prior failed run.
     begin
-      session.delete_qlocal(name: TEST_ENSURE_QLOCAL)
+      session.delete_qlocal(TEST_ENSURE_QLOCAL)
     rescue MQ::REST::Admin::Error # rubocop:disable Lint/SuppressedException
     end
 
@@ -349,7 +350,7 @@ class MqIntegrationTest < Minitest::Test
     assert_equal :updated, result.action
 
     # Cleanup.
-    session.delete_qlocal(name: TEST_ENSURE_QLOCAL)
+    session.delete_qlocal(TEST_ENSURE_QLOCAL)
   end
 
   def test_ensure_channel_lifecycle


### PR DESCRIPTION
# Pull Request

## Summary

- Require name parameter for delete_qlocal, delete_qremote, delete_qalias, and delete_qmodel methods

## Issue Linkage

- Fixes #71

## Testing

- markdownlint
- `bundle exec rake`

## Notes

- -