### PR TITLE
fix(ci): make license_finder check blocking with approved license list

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,7 @@ jobs:
       - name: Run license compliance check
         run: |
           gem install license_finder --no-document
-          license_finder --decisions-file=doc/dependency_decisions.yml || true
+          license_finder --decisions-file=doc/dependency_decisions.yml
 
   # ---------------------------------------------------------------------------
   # Integration tests

--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ htmlcov/
 /.yardoc/
 /_yardoc/
 /doc/
+!/doc/dependency_decisions.yml
 /rdoc/
 doc/yard/
 

--- a/doc/dependency_decisions.yml
+++ b/doc/dependency_decisions.yml
@@ -1,0 +1,31 @@
+---
+- - :permit
+  - MIT
+  - :who:
+    :why:
+    :versions: []
+    :when: 2026-03-01 20:49:16.258089464 Z
+- - :permit
+  - Simplified BSD
+  - :who:
+    :why:
+    :versions: []
+    :when: 2026-03-01 20:49:17.028709111 Z
+- - :permit
+  - New BSD
+  - :who:
+    :why:
+    :versions: []
+    :when: 2026-03-01 20:49:17.705662790 Z
+- - :permit
+  - ruby
+  - :who:
+    :why:
+    :versions: []
+    :when: 2026-03-01 20:49:18.316100224 Z
+- - :permit
+  - GPL-3.0-or-later
+  - :who:
+    :why:
+    :versions: []
+    :when: 2026-03-01 20:49:18.971984481 Z


### PR DESCRIPTION
# Pull Request

## Summary

- Make license_finder blocking by adding approved license decisions and removing || true workaround

## Issue Linkage

- Fixes #78

## Testing

- markdownlint
- `bundle exec rake`

## Notes

- -