### PR TITLE
feat(sync): add SyncConfig construction validation

### DIFF
--- a/lib/mq/rest/admin/sync.rb
+++ b/lib/mq/rest/admin/sync.rb
@@ -13,6 +13,16 @@ module MQ
         # @param timeout_seconds [Float] maximum wait time (default: 30.0)
         # @param poll_interval_seconds [Float] polling interval (default: 1.0)
         def initialize(timeout_seconds: 30.0, poll_interval_seconds: 1.0)
+          unless timeout_seconds.positive?
+            raise ArgumentError,
+                  "timeout_seconds must be positive, got #{timeout_seconds}"
+          end
+
+          unless poll_interval_seconds.positive?
+            raise ArgumentError,
+                  "poll_interval_seconds must be positive, got #{poll_interval_seconds}"
+          end
+
           super
         end
       end

--- a/test/mq/rest/admin/sync_test.rb
+++ b/test/mq/rest/admin/sync_test.rb
@@ -39,6 +39,30 @@ module MQ
           assert_in_delta 60.0, cfg.timeout_seconds
           assert_in_delta 2.0, cfg.poll_interval_seconds
         end
+
+        def test_zero_timeout_raises
+          err = assert_raises(ArgumentError) { SyncConfig.new(timeout_seconds: 0.0) }
+
+          assert_match(/timeout_seconds must be positive/, err.message)
+        end
+
+        def test_negative_timeout_raises
+          err = assert_raises(ArgumentError) { SyncConfig.new(timeout_seconds: -1.0) }
+
+          assert_match(/timeout_seconds must be positive/, err.message)
+        end
+
+        def test_zero_poll_interval_raises
+          err = assert_raises(ArgumentError) { SyncConfig.new(poll_interval_seconds: 0.0) }
+
+          assert_match(/poll_interval_seconds must be positive/, err.message)
+        end
+
+        def test_negative_poll_interval_raises
+          err = assert_raises(ArgumentError) { SyncConfig.new(poll_interval_seconds: -1.0) }
+
+          assert_match(/poll_interval_seconds must be positive/, err.message)
+        end
       end
 
       class SyncResultTest < Minitest::Test


### PR DESCRIPTION
# Pull Request

## Summary

- Reject non-positive timeout_seconds and poll_interval_seconds at SyncConfig construction time

## Issue Linkage

- Fixes #86

## Testing

- markdownlint
- `bundle exec rake`

## Notes

- -