### PR TITLE
refactor: migrate publish workflow to shared reusable workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,123 +11,56 @@ permissions:
   id-token: write
   pull-requests: write
 
-concurrency:
-  group: publish
-  cancel-in-progress: false
-
 jobs:
   publish:
-    name: "publish: release"
-    runs-on: ubuntu-latest
-    env:
-      HAS_RUBYGEMS_KEY: ${{ secrets.RUBYGEMS_API_KEY != '' }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
+    uses: wphillipmoore/standard-actions/.github/workflows/publish-release.yml@develop
+    permissions:
+      attestations: write
+      contents: write
+      id-token: write
+      pull-requests: write
+    with:
+      ecosystem: ruby
+      version-command: >-
+        ruby -e "require_relative 'lib/mq/rest/admin/version'; puts MQ::REST::Admin::VERSION"
+      registry-check-command: >-
+        ruby -e "
+        require 'net/http'; require 'uri'; require 'json';
+        uri = URI('https://rubygems.org/api/v1/versions/mq-rest-admin.json');
+        res = Net::HTTP.get_response(uri);
+        if res.code == '200'
+          versions = JSON.parse(res.body).map { |v| v['number'] };
+          puts versions.include?(ENV['VERSION']) ? 'exists' : 'not_found'
+        else
+          puts 'not_found'
+        end"
+      build-command: >-
+        gem build mq-rest-admin.gemspec -o dist/mq-rest-admin-$VERSION.gem
+      attestation-subject-path: "dist/*"
+      sbom-output-file: "dist/mq-rest-admin-$VERSION.cdx.json"
+      registry-publish-command: >-
+        gem push dist/mq-rest-admin-$VERSION.gem
+      release-title: mq-rest-admin
+      release-notes: |
+        ## Installation
 
-      - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: "3.4"
-          bundler-cache: true
+        ```bash
+        gem install mq-rest-admin -v $VERSION
+        ```
 
-      - name: Extract version
-        id: version
-        run: |
-          version=$(ruby -e "require_relative 'lib/mq/rest/admin/version'; puts MQ::REST::Admin::VERSION")
-          echo "version=$version" >> "$GITHUB_OUTPUT"
-          echo "tag=v$version" >> "$GITHUB_OUTPUT"
+        ## Links
 
-      - name: Check if tag already exists
-        id: tag_check
-        run: |
-          if git rev-parse "${{ steps.version.outputs.tag }}" >/dev/null 2>&1; then
-            echo "exists=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "exists=false" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Check if gem already on RubyGems
-        id: gem_check
-        run: |
-          status=$(ruby -e "
-            require 'net/http'
-            require 'uri'
-            uri = URI('https://rubygems.org/api/v1/versions/mq-rest-admin.json')
-            res = Net::HTTP.get_response(uri)
-            if res.code == '200'
-              require 'json'
-              versions = JSON.parse(res.body).map { |v| v['number'] }
-              puts versions.include?('${{ steps.version.outputs.version }}') ? 'exists' : 'not_found'
-            else
-              puts 'not_found'
-            end
-          ")
-          echo "status=$status" >> "$GITHUB_OUTPUT"
-
-      - name: Build gem
-        if: steps.tag_check.outputs.exists == 'false'
-        run: |
-          mkdir -p dist
-          gem build mq-rest-admin.gemspec -o dist/mq-rest-admin-${{ steps.version.outputs.version }}.gem
-
-      - name: Attest build provenance
-        if: steps.tag_check.outputs.exists == 'false'
-        uses: actions/attest-build-provenance@v3
-        with:
-          subject-path: "dist/*"
-
-      - name: Generate SBOM
-        if: steps.tag_check.outputs.exists == 'false'
-        uses: wphillipmoore/standard-actions/actions/security/trivy@develop
-        with:
-          scan-type: sbom
-          output-file: dist/mq-rest-admin-${{ steps.version.outputs.version }}.cdx.json
-
-      - name: Tag and release
-        if: steps.tag_check.outputs.exists == 'false'
-        uses: wphillipmoore/standard-actions/actions/publish/tag-and-release@develop
-        with:
-          version: ${{ steps.version.outputs.version }}
-          release-title: mq-rest-admin
-          release-notes: |
-            ## Installation
-
-            ```bash
-            gem install mq-rest-admin -v ${{ steps.version.outputs.version }}
-            ```
-
-            ## Links
-
-            - [RubyGems](https://rubygems.org/gems/mq-rest-admin/versions/${{ steps.version.outputs.version }})
-            - [Documentation](https://wphillipmoore.github.io/mq-rest-admin-ruby/)
-          release-artifacts: dist/*
-
-      - name: Publish to RubyGems
-        if: steps.gem_check.outputs.status == 'not_found' && env.HAS_RUBYGEMS_KEY == 'true'
-        env:
-          GEM_HOST_API_KEY: ${{ secrets.RUBYGEMS_API_KEY }}
-        run: gem push dist/mq-rest-admin-${{ steps.version.outputs.version }}.gem
-
-      - name: Generate app token for bump PR
-        if: steps.tag_check.outputs.exists == 'false'
-        id: app-token
-        uses: actions/create-github-app-token@v2
-        with:
-          app-id: ${{ secrets.APP_ID }}
-          private-key: ${{ secrets.APP_PRIVATE_KEY }}
-
-      - name: Version bump PR
-        if: steps.tag_check.outputs.exists == 'false'
-        uses: wphillipmoore/standard-actions/actions/publish/version-bump-pr@develop
-        with:
-          current-version: ${{ steps.version.outputs.version }}
-          version-file: lib/mq/rest/admin/version.rb
-          version-regex: '(VERSION\s*=\s*\x27).*(\x27)'
-          version-replacement: '\g<1>{version}\2'
-          develop-version-command: ruby -e "eval(STDIN.read); puts MQ::REST::Admin::VERSION"
-          post-bump-command: bundle lock --update mq-rest-admin
-          extra-files: Gemfile.lock
-          app-token: ${{ steps.app-token.outputs.token }}
+        - [RubyGems](https://rubygems.org/gems/mq-rest-admin/versions/$VERSION)
+        - [Documentation](https://wphillipmoore.github.io/mq-rest-admin-ruby/)
+      release-artifacts: "dist/*"
+      version-file: lib/mq/rest/admin/version.rb
+      version-regex: '(VERSION\s*=\s*\x27).*(\x27)'
+      version-replacement: '\g<1>{version}\2'
+      develop-version-command: >-
+        ruby -e "eval(STDIN.read); puts MQ::REST::Admin::VERSION"
+      post-bump-command: bundle lock --update mq-rest-admin
+      extra-files: Gemfile.lock
+    secrets:
+      APP_ID: ${{ secrets.APP_ID }}
+      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
+      RUBYGEMS_API_KEY: ${{ secrets.RUBYGEMS_API_KEY }}

--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,2 +1,4 @@
 CHANGELOG.md
 releases/
+AGENTS.md
+CLAUDE.md


### PR DESCRIPTION
## Summary

- Replace per-repo publish.yml with thin caller that delegates to the shared `publish-release.yml` reusable workflow in standard-actions
- All ecosystem-specific behavior is passed as inputs to the shared workflow
- Consistent action refs, step ordering, and SBOM output normalization

Ref wphillipmoore/standard-actions#171

## Test plan

- [ ] Verify CI passes on this branch
- [ ] After standard-actions#171 merges to develop, verify publish workflow runs correctly on next release
- [ ] Confirm idempotency: re-run on existing tag should skip all mutating steps
