### PR TITLE
Container-first validation: remove fallback docker run blocks

### DIFF
--- a/scripts/dev/audit.sh
+++ b/scripts/dev/audit.sh
@@ -4,19 +4,9 @@ set -euo pipefail
 export DOCKER_DEV_IMAGE="${DOCKER_DEV_IMAGE:-dev-ruby:3.4}"
 export DOCKER_TEST_CMD="${DOCKER_TEST_CMD:-bundle install --jobs 4 && bundle exec bundle-audit check --update}"
 
-if command -v docker-test >/dev/null 2>&1; then
-  exec docker-test
+if ! command -v docker-test >/dev/null 2>&1; then
+  echo "ERROR: docker-test not found on PATH." >&2
+  echo "Set up standard-tooling: export PATH=../standard-tooling/scripts/bin:\$PATH" >&2
+  exit 1
 fi
-
-# Fallback: run docker directly if docker-test is not on PATH.
-repo_root="$(cd "$(dirname "$0")/../.." && pwd)"
-
-echo "Image:   ${DOCKER_DEV_IMAGE}"
-echo "Command: ${DOCKER_TEST_CMD}"
-echo "---"
-
-exec docker run --rm \
-  -v "${repo_root}:/workspace" \
-  -w /workspace \
-  "${DOCKER_DEV_IMAGE}" \
-  bash -c "${DOCKER_TEST_CMD}"
+exec docker-test

--- a/scripts/dev/lint.sh
+++ b/scripts/dev/lint.sh
@@ -4,19 +4,9 @@ set -euo pipefail
 export DOCKER_DEV_IMAGE="${DOCKER_DEV_IMAGE:-dev-ruby:3.4}"
 export DOCKER_TEST_CMD="${DOCKER_TEST_CMD:-bundle install --jobs 4 && bundle exec rubocop}"
 
-if command -v docker-test >/dev/null 2>&1; then
-  exec docker-test
+if ! command -v docker-test >/dev/null 2>&1; then
+  echo "ERROR: docker-test not found on PATH." >&2
+  echo "Set up standard-tooling: export PATH=../standard-tooling/scripts/bin:\$PATH" >&2
+  exit 1
 fi
-
-# Fallback: run docker directly if docker-test is not on PATH.
-repo_root="$(cd "$(dirname "$0")/../.." && pwd)"
-
-echo "Image:   ${DOCKER_DEV_IMAGE}"
-echo "Command: ${DOCKER_TEST_CMD}"
-echo "---"
-
-exec docker run --rm \
-  -v "${repo_root}:/workspace" \
-  -w /workspace \
-  "${DOCKER_DEV_IMAGE}" \
-  bash -c "${DOCKER_TEST_CMD}"
+exec docker-test

--- a/scripts/dev/test-integration.sh
+++ b/scripts/dev/test-integration.sh
@@ -20,31 +20,9 @@ export MQ_QM2_REST_BASE_URL="https://qm2:9443/ibmmq/rest/v2"
 export MQ_ADMIN_USER="mqadmin"
 export MQ_ADMIN_PASSWORD="mqadmin"
 
-if command -v docker-test >/dev/null 2>&1; then
-  exec docker-test
+if ! command -v docker-test >/dev/null 2>&1; then
+  echo "ERROR: docker-test not found on PATH." >&2
+  echo "Set up standard-tooling: export PATH=../standard-tooling/scripts/bin:\$PATH" >&2
+  exit 1
 fi
-
-# Fallback: run docker directly if docker-test is not on PATH.
-repo_root="$(cd "$(dirname "$0")/../.." && pwd)"
-
-docker_args=(
-  run --rm
-  -v "${repo_root}:/workspace"
-  -w /workspace
-  --network "${DOCKER_NETWORK}"
-)
-
-# Pass through MQ_* environment variables.
-while IFS='=' read -r name _; do
-  docker_args+=(-e "$name")
-done < <(env | grep '^MQ_' || true)
-
-docker_args+=("${DOCKER_DEV_IMAGE}")
-docker_args+=(bash -c "${DOCKER_TEST_CMD}")
-
-echo "Image:   ${DOCKER_DEV_IMAGE}"
-echo "Command: ${DOCKER_TEST_CMD}"
-echo "Network: ${DOCKER_NETWORK}"
-echo "---"
-
-exec docker "${docker_args[@]}"
+exec docker-test

--- a/scripts/dev/test.sh
+++ b/scripts/dev/test.sh
@@ -4,19 +4,9 @@ set -euo pipefail
 export DOCKER_DEV_IMAGE="${DOCKER_DEV_IMAGE:-dev-ruby:3.4}"
 export DOCKER_TEST_CMD="${DOCKER_TEST_CMD:-bundle install --jobs 4 && bundle exec rake}"
 
-if command -v docker-test >/dev/null 2>&1; then
-  exec docker-test
+if ! command -v docker-test >/dev/null 2>&1; then
+  echo "ERROR: docker-test not found on PATH." >&2
+  echo "Set up standard-tooling: export PATH=../standard-tooling/scripts/bin:\$PATH" >&2
+  exit 1
 fi
-
-# Fallback: run docker directly if docker-test is not on PATH.
-repo_root="$(cd "$(dirname "$0")/../.." && pwd)"
-
-echo "Image:   ${DOCKER_DEV_IMAGE}"
-echo "Command: ${DOCKER_TEST_CMD}"
-echo "---"
-
-exec docker run --rm \
-  -v "${repo_root}:/workspace" \
-  -w /workspace \
-  "${DOCKER_DEV_IMAGE}" \
-  bash -c "${DOCKER_TEST_CMD}"
+exec docker-test

--- a/scripts/dev/typecheck.sh
+++ b/scripts/dev/typecheck.sh
@@ -4,19 +4,9 @@ set -euo pipefail
 export DOCKER_DEV_IMAGE="${DOCKER_DEV_IMAGE:-dev-ruby:3.4}"
 export DOCKER_TEST_CMD="${DOCKER_TEST_CMD:-bundle install --jobs 4 && bundle exec steep check}"
 
-if command -v docker-test >/dev/null 2>&1; then
-  exec docker-test
+if ! command -v docker-test >/dev/null 2>&1; then
+  echo "ERROR: docker-test not found on PATH." >&2
+  echo "Set up standard-tooling: export PATH=../standard-tooling/scripts/bin:\$PATH" >&2
+  exit 1
 fi
-
-# Fallback: run docker directly if docker-test is not on PATH.
-repo_root="$(cd "$(dirname "$0")/../.." && pwd)"
-
-echo "Image:   ${DOCKER_DEV_IMAGE}"
-echo "Command: ${DOCKER_TEST_CMD}"
-echo "---"
-
-exec docker run --rm \
-  -v "${repo_root}:/workspace" \
-  -w /workspace \
-  "${DOCKER_DEV_IMAGE}" \
-  bash -c "${DOCKER_TEST_CMD}"
+exec docker-test


### PR DESCRIPTION
## Summary
- Remove fallback `docker run` blocks from all dev scripts including `test-integration.sh`
- Require `docker-test` on PATH with clear error message

## Test plan
- [ ] Run `scripts/dev/test.sh` — tests pass in container
- [ ] Run `scripts/dev/test-integration.sh` — integration tests work with docker-test
- [ ] Verify clear error when `docker-test` not on PATH

Closes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)