### PR TITLE
ci: use dev-docs container for docs CI

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,6 +18,7 @@ jobs:
   deploy:
     name: "deploy: docs"
     runs-on: ubuntu-latest
+    container: ghcr.io/wphillipmoore/dev-docs:latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -27,8 +28,5 @@ jobs:
       - name: Deploy docs
         uses: wphillipmoore/standard-actions/actions/docs-deploy@develop
         with:
-          version-command: >-
-            ruby -e "require_relative 'lib/mq/rest/admin/version';
-            v = MQ::REST::Admin::VERSION;
-            puts v.split('.')[0..1].join('.')"
+          version-command: grep -oP "VERSION\s*=\s*'\K[^']+" lib/mq/rest/admin/version.rb | cut -d. -f1,2
           checkout-common: "true"


### PR DESCRIPTION
# Pull Request

## Summary

- Run docs workflow inside ghcr.io/wphillipmoore/dev-docs:latest
- Rewrite version extraction from ruby -e to grep, removing Ruby runtime dependency

## Issue Linkage

- Fixes #101

## Testing

- markdownlint
- ci: docs workflow passes with container

## Notes

- Merge after standard-tooling-docker#27 and standard-actions#174
