### PR TITLE
chore(ci): upgrade standard-actions from @v1.3 to @v1.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,7 +138,7 @@ jobs:
   # ---------------------------------------------------------------------------
 
   security-and-standards:
-    uses: wphillipmoore/standard-actions/.github/workflows/ci-security.yml@v1.3
+    uses: wphillipmoore/standard-actions/.github/workflows/ci-security.yml@v1.4
     with:
       language: ruby
       run-standards: ${{ inputs.run-release-gates || 'true' }}
@@ -174,7 +174,7 @@ jobs:
 
       - name: Version divergence gate (PRs targeting develop)
         if: github.event_name == 'pull_request' && github.base_ref == 'develop'
-        uses: wphillipmoore/standard-actions/actions/release-gates/version-divergence@v1.3
+        uses: wphillipmoore/standard-actions/actions/release-gates/version-divergence@v1.4
         with:
           head-version-command: ruby -e "require_relative 'lib/mq/rest/admin/version'; puts MQ::REST::Admin::VERSION"
           main-version-command: git show origin/main:lib/mq/rest/admin/version.rb | ruby -e "eval(STDIN.read); puts MQ::REST::Admin::VERSION"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,7 +26,7 @@ jobs:
           fetch-depth: 0
 
       - name: Deploy docs
-        uses: wphillipmoore/standard-actions/actions/docs-deploy@v1.3
+        uses: wphillipmoore/standard-actions/actions/docs-deploy@v1.4
         with:
           version-command: grep -oP "VERSION\s*=\s*'\K[^']+" lib/mq/rest/admin/version.rb | cut -d. -f1,2
           checkout-common: "true"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   publish:
-    uses: wphillipmoore/standard-actions/.github/workflows/publish-release.yml@v1.3
+    uses: wphillipmoore/standard-actions/.github/workflows/publish-release.yml@v1.4
     permissions:
       attestations: write
       contents: write


### PR DESCRIPTION
## Summary

- Upgrade all standard-actions workflow references from `@v1.3` to `@v1.4`

## What changed in v1.4

- Trivy table-to-stdout output for CI visibility
- Trivy bump to 0.70.0
- CI action pin updates (create-github-app-token v3, attest-build-provenance v4)
- Workflow cleanups

Ref wphillipmoore/standard-actions#245
