### PR TITLE
Align CI job names with CI gates and add [ci] config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
     uses: wphillipmoore/standard-actions/.github/workflows/ci-quality.yml@v1.5
     with:
       language: ruby
-      versions: '["3.4"]'
+      versions: ${{ inputs.ruby-versions || '["3.2", "3.3", "3.4"]' }}
 
   test:
     uses: wphillipmoore/standard-actions/.github/workflows/ci-test.yml@v1.5
@@ -39,10 +39,14 @@ jobs:
       versions: ${{ inputs.ruby-versions || '["3.2", "3.3", "3.4"]' }}
 
   audit:
-    name: "audit / dependencies"
+    name: "audit / dependencies / ${{ matrix.ruby-version }}"
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby-version: ${{ fromJSON(inputs.ruby-versions || '["3.2", "3.3", "3.4"]') }}
     container:
-      image: ghcr.io/wphillipmoore/dev-ruby:3.4
+      image: ghcr.io/wphillipmoore/dev-ruby:${{ matrix.ruby-version }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v6

--- a/standard-tooling.toml
+++ b/standard-tooling.toml
@@ -9,6 +9,10 @@ primary-language = "ruby"
 claude = "Co-Authored-By: wphillipmoore-claude <255925739+wphillipmoore-claude@users.noreply.github.com>"
 codex = "Co-Authored-By: wphillipmoore-codex <255923655+wphillipmoore-codex@users.noreply.github.com>"
 
+[ci]
+versions = ["3.2", "3.3", "3.4"]
+integration-tests = true
+
 [markdownlint]
 ignore = ["docs/site/docs"]
 


### PR DESCRIPTION
# Pull Request

## Summary

- Align CI job names with CI gates and add [ci] config

## Issue Linkage

- Ref #127

## Testing

- `st-docker-run -- st-validate`
- `bundle exec rake`

## Notes

- Ref #127

## Summary

- Expand quality workflow versions from latest-only (`["3.4"]`) to
  full test matrix (`["3.2", "3.3", "3.4"]`) so `quality / lint` and
  `quality / typecheck` checks exist for all Ruby versions
- Add version matrix to bespoke audit job so check names match the
  `audit / dependencies / {version}` pattern expected by CI gates
- Add `[ci]` section to `standard-tooling.toml` with versions and
  integration-tests config so `st-github-config apply` generates the
  CI gates ruleset with required status checks

## Test plan

- [ ] All CI jobs run and produce correctly named status checks
- [ ] `quality / lint / 3.2`, `3.3`, `3.4` all exist
- [ ] `audit / dependencies / 3.2`, `3.3`, `3.4` all exist
- [ ] `st-github-config apply` creates CI gates ruleset after merge