### PR TITLE
chore: migrate to mq-rest-admin-project org and vergil tooling

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,13 +1,13 @@
 {
   "extraKnownMarketplaces": {
-    "standard-tooling-marketplace": {
+    "vergil-marketplace": {
       "source": {
         "source": "github",
-        "repo": "wphillipmoore/standard-tooling-plugin"
+        "repo": "vergil-project/vergil-plugin"
       }
     }
   },
   "enabledPlugins": {
-    "standard-tooling@standard-tooling-marketplace": true
+    "vergil@vergil-marketplace": true
   }
 }

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-# Canonical source: wphillipmoore/standard-tooling/.github/ISSUE_TEMPLATE/config.yml
+# Canonical source: vergil-project/vergil-tooling/.github/ISSUE_TEMPLATE/config.yml
 # Do not modify repo-local copies — update the canonical source and re-sync.
 #
 blank_issues_enabled: false

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,2 +1,2 @@
 > **Do not create PRs manually.**
-> Use [`st-submit-pr`](https://wphillipmoore.github.io/standard-tooling/reference/dev/submit-pr/).
+> Use [`vrg-submit-pr`](https://vergil-project.github.io/vergil-tooling/reference/dev/submit-pr/).

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,4 +1,4 @@
-# https://github.com/wphillipmoore/standard-actions/blob/develop/.github/workflows/README.md
+# https://github.com/vergil-project/vergil-actions/blob/develop/.github/workflows/README.md
 name: CD
 
 on:
@@ -14,20 +14,22 @@ permissions:
 
 jobs:
   docs:
-    uses: wphillipmoore/standard-actions/.github/workflows/cd-docs.yml@v1.5
+    uses: vergil-project/vergil-actions/.github/workflows/cd-docs.yml@v2.0
     with:
       pre-deploy-command: >-
         git clone --depth 1 --branch develop
-        https://github.com/wphillipmoore/mq-rest-admin-common.git
+        https://github.com/mq-rest-admin-project/mq-rest-admin-common.git
         .mq-rest-admin-common
     permissions:
       contents: write
 
   release:
     if: github.ref == 'refs/heads/main'
-    uses: wphillipmoore/standard-actions/.github/workflows/cd-release.yml@v1.5
+    uses: vergil-project/vergil-actions/.github/workflows/cd-release.yml@v2.0
     with:
       language: ruby
       container-tag: "3.4"
       registry-publish: true
-    secrets: inherit
+    secrets:
+      APP_CLIENT_ID: ${{ secrets.APP_CLIENT_ID }}
+      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-# https://github.com/wphillipmoore/standard-actions/blob/develop/.github/workflows/README.md
+# https://github.com/vergil-project/vergil-actions/blob/develop/.github/workflows/README.md
 name: CI
 
 on:
@@ -27,7 +27,7 @@ concurrency:
 
 jobs:
   audit:
-    uses: wphillipmoore/standard-actions/.github/workflows/ci-audit.yml@v1.5
+    uses: vergil-project/vergil-actions/.github/workflows/ci-audit.yml@v2.0
     with:
       language: ruby
       versions: ${{ inputs.ruby-versions || '["3.2", "3.3", "3.4"]' }}
@@ -50,7 +50,7 @@ jobs:
           bundler-cache: true
 
       - name: Setup MQ environment
-        uses: wphillipmoore/mq-rest-admin-dev-environment/.github/actions/setup-mq@main
+        uses: mq-rest-admin-project/mq-rest-admin-dev-environment/.github/actions/setup-mq@main
         with:
           project-name: mqrest-ruby-${{ matrix.project-suffix }}
           qm1-rest-port: ${{ matrix.qm1-rest-port }}
@@ -68,13 +68,13 @@ jobs:
           bundle exec rake integration
 
   quality:
-    uses: wphillipmoore/standard-actions/.github/workflows/ci-quality.yml@v1.5
+    uses: vergil-project/vergil-actions/.github/workflows/ci-quality.yml@v2.0
     with:
       language: ruby
       versions: ${{ inputs.ruby-versions || '["3.2", "3.3", "3.4"]' }}
 
   security:
-    uses: wphillipmoore/standard-actions/.github/workflows/ci-security.yml@v1.5
+    uses: vergil-project/vergil-actions/.github/workflows/ci-security.yml@v2.0
     with:
       language: ruby
       run-standards: ${{ inputs.run-release != 'false' }}
@@ -84,13 +84,13 @@ jobs:
       security-events: write
 
   test:
-    uses: wphillipmoore/standard-actions/.github/workflows/ci-test.yml@v1.5
+    uses: vergil-project/vergil-actions/.github/workflows/ci-test.yml@v2.0
     with:
       language: ruby
       versions: ${{ inputs.ruby-versions || '["3.2", "3.3", "3.4"]' }}
 
   version:
-    uses: wphillipmoore/standard-actions/.github/workflows/ci-version-bump.yml@v1.5
+    uses: vergil-project/vergil-actions/.github/workflows/ci-version-bump.yml@v2.0
     with:
       language: ruby
       run-release: ${{ inputs.run-release != 'false' }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,8 @@
 # Agent Instructions
 
-**Standards reference**: <https://github.com/wphillipmoore/standards-and-conventions>
-— active standards documentation lives in the standard-tooling repository under `docs/`.
-Repository profile: `standard-tooling.toml`.
+**Standards reference**: <https://github.com/vergil-project/vergil-tooling>
+— active standards documentation lives in the vergil-tooling repository under `docs/`.
+Repository profile: `vergil.toml`.
 
 ## User Overrides (Optional)
 
@@ -13,15 +13,15 @@ briefly and continue.
 ## Canonical Standards
 
 This repository follows the canonical standards and conventions in the
-`standards-and-conventions` repository.
+`vergil-tooling` repository.
 
 Resolve the local path (preferred):
 
-- `../standards-and-conventions`
+- `../vergil-tooling`
 
 If the local path is unavailable, use the canonical web source:
 
-- <https://github.com/wphillipmoore/standards-and-conventions>
+- <https://github.com/vergil-project/vergil-tooling>
 
 If the canonical standards cannot be retrieved, treat it as a fatal
 exception and stop.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,9 +2,9 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
-**Standards reference**: <https://github.com/wphillipmoore/standards-and-conventions>
-— active standards documentation lives in the standard-tooling repository under `docs/`.
-Repository profile: `standard-tooling.toml`.
+**Standards reference**: <https://github.com/vergil-project/vergil-tooling>
+— active standards documentation lives in the vergil-tooling repository under `docs/`.
+Repository profile: `vergil.toml`.
 
 ## Memory management
 
@@ -15,9 +15,9 @@ plugin/skill issue) before writing. See that file for the full
 workflow.
 
 Available skills:
-- `/standard-tooling:memory-init` — set up or update the policy header
+- `/vergil:memory-init` — set up or update the policy header
   in a project's `MEMORY.md`.
-- `/standard-tooling:memory-audit` — structured collaborative review
+- `/vergil:memory-audit` — structured collaborative review
   of memory files.
 
 ## Parallel AI agent development
@@ -28,9 +28,9 @@ while preserving shared project memory (which Claude Code derives from the
 session's starting CWD).
 
 **Canonical spec:**
-[`standard-tooling/docs/specs/worktree-convention.md`](https://github.com/wphillipmoore/standard-tooling/blob/develop/docs/specs/worktree-convention.md)
+[`vergil-tooling/docs/specs/worktree-convention.md`](https://github.com/vergil-project/vergil-tooling/blob/develop/docs/specs/worktree-convention.md)
 — full rationale, trust model, failure modes, and memory-path implications.
-The canonical text lives in `standard-tooling`; this section is the local
+The canonical text lives in `vergil-tooling`; this section is the local
 on-ramp.
 
 ### Structure
@@ -97,16 +97,16 @@ translation between Ruby idioms and native MQSC parameter names.
 
 **Status**: Pre-alpha (initial setup)
 
-**Canonical Standards**: This repository follows standards at <https://github.com/wphillipmoore/standards-and-conventions> (local path: `../standards-and-conventions` if available)
+**Canonical Standards**: This repository follows standards at <https://github.com/vergil-project/vergil-tooling> (local path: `../vergil-tooling` if available)
 
 ## Development Commands
 
 ### Standard Tooling
 
 ```bash
-cd ../standard-tooling && uv sync                                                # Install standard-tooling
-export PATH="../standard-tooling/.venv/bin:../standard-tooling/scripts/bin:$PATH" # Put tools on PATH
-git config core.hooksPath ../standard-tooling/scripts/lib/git-hooks               # Enable git hooks
+cd ../vergil-tooling && uv sync                                                # Install vergil-tooling
+export PATH="../vergil-tooling/.venv/bin:../vergil-tooling/scripts/bin:$PATH" # Put tools on PATH
+git config core.hooksPath ../vergil-tooling/scripts/lib/git-hooks               # Enable git hooks
 ```
 
 ### Environment Setup
@@ -118,12 +118,12 @@ bundle install
 ### Validation
 
 ```bash
-st-docker-run -- st-validate   # Canonical validation (runs in dev container)
+vrg-docker-run -- vrg-validate   # Canonical validation (runs in dev container)
 ```
 
 ### CI
 
-PR CI (`.github/workflows/ci.yml`) uses standard-actions v1.5 reusable
+PR CI (`.github/workflows/ci.yml`) uses vergil-actions v2.0 reusable
 workflows for quality (lint, typecheck), unit tests (Ruby 3.2/3.3/3.4
 matrix), security (CodeQL, Trivy, Semgrep, standards), and release gates.
 Bespoke jobs handle dependency audit (license_finder with repo-specific
@@ -132,13 +132,13 @@ decisions file) and integration tests (MQ containers).
 ### Local MQ Container
 
 The MQ development environment is owned by the
-[mq-rest-admin-dev-environment](https://github.com/wphillipmoore/mq-rest-admin-dev-environment)
+[mq-rest-admin-dev-environment](https://github.com/mq-rest-admin-project/mq-rest-admin-dev-environment)
 repository. Clone it as a sibling directory before running lifecycle
 scripts:
 
 ```bash
 # Prerequisite (one-time)
-git clone https://github.com/wphillipmoore/mq-rest-admin-dev-environment.git ../mq-rest-admin-dev-environment
+git clone https://github.com/mq-rest-admin-project/mq-rest-admin-dev-environment.git ../mq-rest-admin-dev-environment
 
 # Start the containerized MQ queue managers
 ./scripts/dev/mq_start.sh

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (8.1.2)
+    activesupport (8.1.3)
       base64
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.3.1)
@@ -22,7 +22,7 @@ GEM
       uri (>= 0.13.1)
     ast (2.4.3)
     base64 (0.3.0)
-    bigdecimal (4.0.1)
+    bigdecimal (4.1.2)
     bundler-audit (0.9.3)
       bundler (>= 1.2.0)
       thor (~> 1.0)
@@ -37,7 +37,7 @@ GEM
     fileutils (1.8.0)
     i18n (1.14.8)
       concurrent-ruby (~> 1.0)
-    json (2.19.2)
+    json (2.19.5)
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
     listen (3.10.0)
@@ -127,7 +127,7 @@ GEM
     unicode-emoji (4.2.0)
     uri (1.1.1)
     webrick (1.9.2)
-    yard (0.9.38)
+    yard (0.9.43)
 
 PLATFORMS
   ruby
@@ -151,10 +151,10 @@ DEPENDENCIES
   yard (~> 0.9)
 
 CHECKSUMS
-  activesupport (8.1.2) sha256=88842578ccd0d40f658289b0e8c842acfe9af751afee2e0744a7873f50b6fdae
+  activesupport (8.1.3) sha256=21a5e0dfbd4c3ddd9e1317ec6a4d782fa226e7867dc70b0743acda81a1dca20e
   ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
-  bigdecimal (4.0.1) sha256=8b07d3d065a9f921c80ceaea7c9d4ae596697295b584c296fe599dd0ad01c4a7
+  bigdecimal (4.1.2) sha256=53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd
   bundler-audit (0.9.3) sha256=81c8766c71e47d0d28a0f98c7eed028539f21a6ea3cd8f685eb6f42333c9b4e9
   concurrent-ruby (1.3.6) sha256=6b56837e1e7e5292f9864f34b69c5a2cbc75c0cf5338f1ce9903d10fa762d5ab
   connection_pool (3.0.2) sha256=33fff5ba71a12d2aa26cb72b1db8bba2a1a01823559fb01d29eb74c286e62e0a
@@ -166,7 +166,7 @@ CHECKSUMS
   ffi (1.17.3-x86_64-linux-gnu) sha256=3746b01f677aae7b16dc1acb7cb3cc17b3e35bdae7676a3f568153fb0e2c887f
   fileutils (1.8.0) sha256=8c6b1df54e2540bdb2f39258f08af78853aa70bad52b4d394bbc6424593c6e02
   i18n (1.14.8) sha256=285778639134865c5e0f6269e0b818256017e8cde89993fdfcbfb64d088824a5
-  json (2.19.2) sha256=e7e1bd318b2c37c4ceee2444841c86539bc462e81f40d134cf97826cb14e83cf
+  json (2.19.5) sha256=218a18553e4801d579ca7e0f5bc72bafd776d7397238a1fb4e74db5b0a812c59
   language_server-protocol (3.17.0.5) sha256=fd1e39a51a28bf3eec959379985a72e296e9f9acfce46f6a79d31ca8760803cc
   lint_roller (1.1.0) sha256=2c0c845b632a7d172cb849cc90c1bce937a28c5c8ccccb50dfd46a485003cc87
   listen (3.10.0) sha256=c6e182db62143aeccc2e1960033bebe7445309c7272061979bb098d03760c9d2
@@ -205,7 +205,7 @@ CHECKSUMS
   unicode-emoji (4.2.0) sha256=519e69150f75652e40bf736106cfbc8f0f73aa3fb6a65afe62fefa7f80b0f80f
   uri (1.1.1) sha256=379fa58d27ffb1387eaada68c749d1426738bd0f654d812fcc07e7568f5c57c6
   webrick (1.9.2) sha256=beb4a15fc474defed24a3bda4ffd88a490d517c9e4e6118c3edce59e45864131
-  yard (0.9.38) sha256=721fb82afb10532aa49860655f6cc2eaa7130889df291b052e1e6b268283010f
+  yard (0.9.43) sha256=cf8733a8f0485df2a162927e9b5f182215a61f6d22de096b8f402c726a1c5821
 
 BUNDLED WITH
   4.0.7

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ queues.each { |q| puts q["queue_name"] }
 
 ## Documentation
 
-Full documentation: <https://wphillipmoore.github.io/mq-rest-admin-ruby/>
+Full documentation: <https://mq-rest-admin-project.github.io/mq-rest-admin-ruby/>
 
 ## Development
 

--- a/docs/repository-standards.md
+++ b/docs/repository-standards.md
@@ -14,7 +14,7 @@
 - Before modifying any files, check the current branch with `git status -sb`.
 - If on `develop`, create a short-lived `feature/*` branch or ask for explicit approval to proceed on `develop`.
 - If approval is granted to work on `develop`, call it out in the response and proceed only for that user-approved scope.
-- Enable repository git hooks before committing: `git config core.hooksPath ../standard-tooling/scripts/lib/git-hooks`.
+- Enable repository git hooks before committing: `git config core.hooksPath ../vergil-tooling/scripts/lib/git-hooks`.
 
 ## Local validation
 
@@ -29,7 +29,7 @@ bundle exec rake
 Required for daily workflow:
 
 - Ruby 3.2+, Bundler
-- `st-docker-run -- st-validate` (canonical validation)
+- `vrg-docker-run -- vrg-validate` (canonical validation)
 
 Required for integration testing:
 
@@ -46,13 +46,13 @@ Required for integration testing:
 
 ## Commit and PR scripts
 
-AI agents **must** use the `st-commit` and `st-submit-pr` scripts for commits
+AI agents **must** use the `vrg-commit` and `vrg-submit-pr` scripts for commits
 and PR submission. Do not construct commit messages or PR bodies manually.
 
 ### Committing
 
 ```bash
-st-commit \
+vrg-commit \
   --type TYPE --message MESSAGE --agent AGENT \
   [--scope SCOPE] [--body BODY]
 ```
@@ -65,12 +65,12 @@ st-commit \
 - `--body` (optional): detailed commit body
 
 The script resolves the correct `Co-Authored-By` identity from
-`standard-tooling.toml` and the git hooks validate the result.
+`vergil.toml` and the git hooks validate the result.
 
 ### Submitting PRs
 
 ```bash
-st-submit-pr \
+vrg-submit-pr \
   --issue NUMBER --summary TEXT \
   [--linkage KEYWORD] [--title TEXT] \
   [--notes TEXT] [--docs-only] [--dry-run]

--- a/docs/site/docs/development/contributing.md
+++ b/docs/site/docs/development/contributing.md
@@ -68,7 +68,7 @@ bundle exec rubocop && bundle exec rake test
 - **Claude Code**: reads `CLAUDE.md`, which loads repository standards
   via include directives.
 - **Codex and other agents**: reads `AGENTS.md`, which loads the same
-  standards plus shared skills from the `standards-and-conventions`
+  standards plus shared skills from the `vergil-tooling`
   repository.
 
 ### Quality expectations

--- a/docs/site/docs/development/developer-setup.md
+++ b/docs/site/docs/development/developer-setup.md
@@ -15,9 +15,9 @@ mq-rest-admin depends on two sibling repositories:
 
 | Repository | Purpose |
 | --- | --- |
-| [mq-rest-admin-ruby](https://github.com/wphillipmoore/mq-rest-admin-ruby) | This project |
-| [standards-and-conventions](https://github.com/wphillipmoore/standards-and-conventions) | Canonical project standards (referenced by `AGENTS.md` and git hooks) |
-| [mq-rest-admin-dev-environment](https://github.com/wphillipmoore/mq-rest-admin-dev-environment) | Dockerized MQ test infrastructure (local and CI) |
+| [mq-rest-admin-ruby](https://github.com/mq-rest-admin-project/mq-rest-admin-ruby) | This project |
+| [vergil-tooling](https://github.com/vergil-project/vergil-tooling) | Canonical project standards (referenced by `AGENTS.md` and git hooks) |
+| [mq-rest-admin-dev-environment](https://github.com/mq-rest-admin-project/mq-rest-admin-dev-environment) | Dockerized MQ test infrastructure (local and CI) |
 
 ## Recommended directory layout
 
@@ -26,15 +26,15 @@ Clone all three repositories as siblings:
 ```text
 ~/dev/
 ├── mq-rest-admin-ruby/
-├── standards-and-conventions/
+├── vergil-tooling/
 └── mq-rest-admin-dev-environment/
 ```
 
 ```bash
 cd ~/dev
-git clone https://github.com/wphillipmoore/mq-rest-admin-ruby.git
-git clone https://github.com/wphillipmoore/standards-and-conventions.git
-git clone https://github.com/wphillipmoore/mq-rest-admin-dev-environment.git
+git clone https://github.com/mq-rest-admin-project/mq-rest-admin-ruby.git
+git clone https://github.com/vergil-project/vergil-tooling.git
+git clone https://github.com/mq-rest-admin-project/mq-rest-admin-dev-environment.git
 ```
 
 ## Installing dependencies

--- a/docs/site/docs/examples.md
+++ b/docs/site/docs/examples.md
@@ -36,7 +36,7 @@ summary for each queue manager.
 ruby examples/health_check.rb
 ```
 
-See [`examples/health_check.rb`](https://github.com/wphillipmoore/mq-rest-admin-ruby/blob/main/examples/health_check.rb) for implementation details.
+See [`examples/health_check.rb`](https://github.com/mq-rest-admin-project/mq-rest-admin-ruby/blob/main/examples/health_check.rb) for implementation details.
 
 ## Queue depth monitor
 
@@ -47,7 +47,7 @@ approaching capacity, and sorts by depth percentage.
 ruby examples/queue_depth_monitor.rb
 ```
 
-See [`examples/queue_depth_monitor.rb`](https://github.com/wphillipmoore/mq-rest-admin-ruby/blob/main/examples/queue_depth_monitor.rb) for implementation details.
+See [`examples/queue_depth_monitor.rb`](https://github.com/mq-rest-admin-project/mq-rest-admin-ruby/blob/main/examples/queue_depth_monitor.rb) for implementation details.
 
 ## Channel status report
 
@@ -58,7 +58,7 @@ channels that are defined but not running, and shows connection details.
 ruby examples/channel_status.rb
 ```
 
-See [`examples/channel_status.rb`](https://github.com/wphillipmoore/mq-rest-admin-ruby/blob/main/examples/channel_status.rb) for implementation details.
+See [`examples/channel_status.rb`](https://github.com/mq-rest-admin-project/mq-rest-admin-ruby/blob/main/examples/channel_status.rb) for implementation details.
 
 ## Environment provisioner
 
@@ -69,7 +69,7 @@ across two queue managers, then verifies connectivity. Includes teardown.
 ruby examples/provision_environment.rb
 ```
 
-See [`examples/provision_environment.rb`](https://github.com/wphillipmoore/mq-rest-admin-ruby/blob/main/examples/provision_environment.rb) for implementation details.
+See [`examples/provision_environment.rb`](https://github.com/mq-rest-admin-project/mq-rest-admin-ruby/blob/main/examples/provision_environment.rb) for implementation details.
 
 ## Dead letter queue inspector
 
@@ -80,7 +80,7 @@ and suggests actions when messages are present.
 ruby examples/dlq_inspector.rb
 ```
 
-See [`examples/dlq_inspector.rb`](https://github.com/wphillipmoore/mq-rest-admin-ruby/blob/main/examples/dlq_inspector.rb) for implementation details.
+See [`examples/dlq_inspector.rb`](https://github.com/mq-rest-admin-project/mq-rest-admin-ruby/blob/main/examples/dlq_inspector.rb) for implementation details.
 
 ## Queue status and connection handles
 
@@ -92,4 +92,4 @@ structures into uniform flat hashes.
 ruby examples/queue_status.rb
 ```
 
-See [`examples/queue_status.rb`](https://github.com/wphillipmoore/mq-rest-admin-ruby/blob/main/examples/queue_status.rb) for implementation details.
+See [`examples/queue_status.rb`](https://github.com/mq-rest-admin-project/mq-rest-admin-ruby/blob/main/examples/queue_status.rb) for implementation details.

--- a/docs/site/mkdocs.yml
+++ b/docs/site/mkdocs.yml
@@ -1,7 +1,7 @@
 site_name: mq-rest-admin (Ruby)
-site_url: https://wphillipmoore.github.io/mq-rest-admin-ruby/
+site_url: https://mq-rest-admin-project.github.io/mq-rest-admin-ruby/
 site_description: Ruby wrapper for the IBM MQ administrative REST API
-repo_url: https://github.com/wphillipmoore/mq-rest-admin-ruby
+repo_url: https://github.com/mq-rest-admin-project/mq-rest-admin-ruby
 repo_name: mq-rest-admin-ruby
 edit_uri: ""
 

--- a/docs/standards-and-conventions.md
+++ b/docs/standards-and-conventions.md
@@ -1,7 +1,7 @@
 # mq-rest-admin-ruby Standards and Conventions
 
 This repository follows the canonical standards at:
-<https://github.com/wphillipmoore/standards-and-conventions>
+<https://github.com/vergil-project/vergil-tooling>
 
 ## Table of Contents
 
@@ -9,7 +9,7 @@ This repository follows the canonical standards at:
 - [Project-specific overlay](#project-specific-overlay)
 
 ## Canonical references
-<!-- include: ../standards-and-conventions/docs/standards-and-conventions.md -->
+<!-- include: ../vergil-tooling/docs/standards-and-conventions.md -->
 
 ## Project-specific overlay
 

--- a/mq-rest-admin.gemspec
+++ b/mq-rest-admin.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
                      'IBM MQ 9.4 runCommandJSON REST endpoint, with automatic ' \
                      'attribute name translation between Ruby idioms and native ' \
                      'MQSC parameter names.'
-  spec.homepage = 'https://github.com/wphillipmoore/mq-rest-admin-ruby'
+  spec.homepage = 'https://github.com/mq-rest-admin-project/mq-rest-admin-ruby'
   spec.license = 'GPL-3.0-or-later'
   spec.required_ruby_version = '>= 3.2.0'
 

--- a/scripts/dev/docs-setup.sh
+++ b/scripts/dev/docs-setup.sh
@@ -25,7 +25,7 @@ fi
 
 if [ ! -d "$COMMON_REPO" ]; then
     echo "Error: Common repo not found at $COMMON_REPO"
-    echo "Clone it with: git clone https://github.com/wphillipmoore/mq-rest-admin-common.git $COMMON_REPO"
+    echo "Clone it with: git clone https://github.com/mq-rest-admin-project/mq-rest-admin-common.git $COMMON_REPO"
     exit 1
 fi
 

--- a/scripts/dev/test-integration.sh
+++ b/scripts/dev/test-integration.sh
@@ -20,9 +20,9 @@ export MQ_QM2_REST_BASE_URL="https://qm2:9443/ibmmq/rest/v2"
 export MQ_ADMIN_USER="mqadmin"
 export MQ_ADMIN_PASSWORD="mqadmin"
 
-if ! command -v st-docker-test >/dev/null 2>&1; then
-  echo "ERROR: st-docker-test not found on PATH." >&2
-  echo "Set up standard-tooling: export PATH=../standard-tooling/.venv/bin:\$PATH" >&2
+if ! command -v vrg-docker-test >/dev/null 2>&1; then
+  echo "ERROR: vrg-docker-test not found on PATH." >&2
+  echo "Set up vergil-tooling: export PATH=../vergil-tooling/.venv/bin:\$PATH" >&2
   exit 1
 fi
-exec st-docker-test
+exec vrg-docker-test

--- a/vergil.toml
+++ b/vergil.toml
@@ -6,8 +6,7 @@ release-model = "artifact-publishing"
 primary-language = "ruby"
 
 [project.co-authors]
-claude = "Co-Authored-By: wphillipmoore-claude <255925739+wphillipmoore-claude@users.noreply.github.com>"
-codex = "Co-Authored-By: wphillipmoore-codex <255923655+wphillipmoore-codex@users.noreply.github.com>"
+agent = "Co-Authored-By: wphillipmoore-agent <284101533+wphillipmoore-agent@users.noreply.github.com>"
 
 [ci]
 versions = ["3.2", "3.3", "3.4"]
@@ -21,4 +20,4 @@ release = true
 docs = true
 
 [dependencies]
-standard-tooling = "v1.4"
+vergil = "v2.0"


### PR DESCRIPTION
## Summary

- Rename `standard-tooling.toml` to `vergil.toml` and adopt vergil v2.0 dependency
- Update all CI/CD workflows from `wphillipmoore/standard-actions@v1.5` to `vergil-project/vergil-actions@v2.0`
- Replace `secrets: inherit` with explicit secrets block in cd.yml
- Update all repository and documentation URLs from `wphillipmoore` to `mq-rest-admin-project` org
- Consolidate co-author entries to single `wphillipmoore-agent` identity
- Migrate Claude Code plugin config from `standard-tooling-marketplace` to `vergil-marketplace`
- Update all references to `standard-tooling` CLI tools (`st-*`) to vergil equivalents (`vrg-*`)

Ref mq-rest-admin-project/mq-rest-admin-common#195

## Test plan

- [ ] Verify CI workflows resolve `vergil-project/vergil-actions@v2.0` correctly
- [ ] Verify MQ dev-environment action resolves from `mq-rest-admin-project` org
- [ ] Confirm gemspec homepage URL points to new org
- [ ] Confirm docs site URL points to `mq-rest-admin-project.github.io`
- [ ] Grep confirms no stale `wphillipmoore` references remain (except co-author line in vergil.toml and personal email in gemspec)

🤖 Generated with [Claude Code](https://claude.com/claude-code)