### PR TITLE
ci(epic-rollup): add event-driven epic-rollup caller

### DIFF
--- a/.github/workflows/epic-rollup.yml
+++ b/.github/workflows/epic-rollup.yml
@@ -1,0 +1,25 @@
+name: Epic Rollup
+
+# Event-driven epic rollup (epic vergil-project/.github#75). When any issue in
+# this repo closes, hand off to the reusable ops-epic-rollup workflow, which
+# runs `vrg-epic-rollup` to close the parent epic once all its sibling tasks are
+# closed. A no-op unless the closed issue is a managed task with a finite,
+# non-standing epic parent, so it is safe to fire on every close. Per repo
+# convention, all logic (token, checkout, install, run) lives in the reusable
+# workflow; this caller is thin (cf. ops.yml).
+
+on:
+  issues:
+    types: [closed]
+
+permissions:
+  contents: read
+
+jobs:
+  epic-rollup:
+    uses: vergil-project/vergil-actions/.github/workflows/ops-epic-rollup.yml@v2.1
+    permissions:
+      contents: read
+    secrets:
+      APP_CLIENT_ID: ${{ secrets.APP_CLIENT_ID }}
+      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}


### PR DESCRIPTION
# Pull Request

## Summary

- Add .github/workflows/epic-rollup.yml, a thin caller that fires on issues.closed and hands off to the reusable ops-epic-rollup.yml@v2.1 so a merged managed task rolls up its finite parent epic automatically.

## Issue Linkage

- Closes #157

## Notes

- Phase 3 of event-driven epic rollup (mechanism built in epic vergil-project/.github#75). Adds a thin caller that fires on issues.closed and hands off to the reusable ops-epic-rollup.yml@v2.1, so a merged managed task in this repo closes and its finite parent epic rolls up automatically.

All logic (token, checkout, install, run) lives in the reusable workflow; this caller only forwards the APP_CLIENT_ID / APP_PRIVATE_KEY org secrets. It is a no-op unless the closed issue is a managed task with a finite (non-standing) epic parent, so it is safe to fire on every close.

Prerequisite: APP_CLIENT_ID / APP_PRIVATE_KEY secrets must be available to this repo (org-level). If absent, the caller fails loudly rather than silently.